### PR TITLE
refactor: rename cmd directory

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/tinfoilsh/stransport/client"
+	"github.com/tinfoilsh/stransport/identity"
+)
+
+var (
+	serverURL    = flag.String("s", "http://localhost:8080", "server URL")
+	identityFile = flag.String("i", "client_identity.json", "client identity file")
+	verbose      = flag.Bool("v", false, "verbose logging")
+)
+
+func main() {
+	flag.Parse()
+	if *verbose {
+		log.SetLevel(log.DebugLevel)
+		log.Debug("Verbose logging enabled")
+	}
+
+	clientIdentity, err := identity.FromFile(*identityFile)
+	if err != nil {
+		log.Fatalf("failed to get client identity: %v", err)
+	}
+
+	log.WithFields(log.Fields{
+		"public_key_hex": hex.EncodeToString(clientIdentity.MarshalPublicKey()),
+	}).Info("Client identity")
+
+	secureTransport, err := client.NewTransport(*serverURL, clientIdentity)
+	if err != nil {
+		log.Fatalf("failed to create secure client: %v", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: secureTransport,
+	}
+
+	testSecureEndpoint(httpClient)
+	testStreamEndpoint(httpClient)
+}
+
+func testSecureEndpoint(httpClient *http.Client) {
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/secure", *serverURL), bytes.NewBuffer([]byte("nate")))
+	if err != nil {
+		log.Fatalf("failed to create request: %v", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		log.Fatalf("failed to make secure request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("failed to read response body: %v", err)
+	}
+
+	log.Infof("Response body: %s", string(body))
+}
+
+func testStreamEndpoint(httpClient *http.Client) {
+	log.Info("Testing streaming endpoint...")
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/stream", *serverURL), nil)
+	if err != nil {
+		log.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		log.Fatalf("failed to make stream request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	log.Info("Streaming response:")
+
+	buf := make([]byte, 1024)
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			os.Stdout.Write(buf[:n])
+		}
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			log.Errorf("Error reading stream: %v", err)
+			break
+		}
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"time"
+
+	logrus "github.com/sirupsen/logrus"
+
+	"github.com/tinfoilsh/stransport/identity"
+	"github.com/tinfoilsh/stransport/middleware"
+	"github.com/tinfoilsh/stransport/protocol"
+)
+
+var (
+	listenAddr      = flag.String("l", ":8080", "listen address")
+	identityFile    = flag.String("i", "server_identity.json", "identity file")
+	verbose         = flag.Bool("v", false, "verbose logging")
+	permitPlaintext = flag.Bool("p", false, "permit plaintext requests")
+)
+
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Ehbp-Client-Public-Key, Ehbp-Encapsulated-Key")
+		w.Header().Set("Access-Control-Expose-Headers", "Ehbp-Encapsulated-Key, Content-Type")
+		w.Header().Set("Access-Control-Max-Age", "86400")
+
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func main() {
+	flag.Parse()
+	if *verbose {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.Debug("Verbose logging enabled")
+	}
+
+	serverIdentity, err := identity.FromFile(*identityFile)
+	if err != nil {
+		logrus.Fatalf("Failed to get identity: %v", err)
+	}
+
+	secureServer := middleware.NewSecureServer(serverIdentity, *permitPlaintext)
+
+	logrus.WithFields(logrus.Fields{
+		"public_key_hex":   hex.EncodeToString(serverIdentity.MarshalPublicKey()),
+		"permit_plaintext": *permitPlaintext,
+	}).Info("Server identity")
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(protocol.KeysPath, serverIdentity.ConfigHandler)
+
+	mux.Handle("/secure", secureServer.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			logrus.Errorf("Failed to read request body: %v", err)
+			http.Error(w, "Failed to read request body", http.StatusInternalServerError)
+			return
+		}
+		logrus.Debugf("Received request body: %s", string(body))
+
+		response := []byte("Hello, " + string(body))
+		logrus.Debugf("Sending response: %s", string(response))
+
+		if _, err := w.Write(response); err != nil {
+			logrus.Errorf("Failed to write response: %v", err)
+			return
+		}
+		logrus.Debug("Response sent successfully")
+	})))
+
+	mux.Handle("/stream", secureServer.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logrus.Debug("Received stream request")
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Transfer-Encoding", "chunked")
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			logrus.WithFields(logrus.Fields{
+				"type": fmt.Sprintf("%T", w),
+			}).Error("Response writer does not implement http.Flusher")
+			http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+			return
+		}
+		logrus.Debug("Stream flusher initialized successfully")
+
+		for i := 1; i <= 20; i++ {
+			_, err := fmt.Fprintf(w, "Number: %d\n", i)
+			if err != nil {
+				logrus.Errorf("Error writing to stream: %v", err)
+				return
+			}
+			flusher.Flush()
+			time.Sleep(100 * time.Millisecond)
+		}
+	})))
+
+	proxyUpstream, err := url.Parse("http://localhost:11434")
+	if err != nil {
+		logrus.Fatalf("Failed to parse proxy backend URL: %v", err)
+	}
+	proxy := httputil.NewSingleHostReverseProxy(proxyUpstream)
+	proxy.ErrorLog = log.New(os.Stderr, "proxy: ", log.LstdFlags)
+
+	mux.Handle("/", secureServer.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxy.ServeHTTP(w, r)
+	})))
+
+	logrus.Printf("Listening on %s", *listenAddr)
+	logrus.Fatal(http.ListenAndServe(*listenAddr, corsMiddleware(mux)))
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved the client and server binaries into cmd/ and added clear entrypoints. Introduces a secure demo server with CORS, streaming, and reverse proxy, plus a simple client to test it.

- **Refactors**
  - Reorganized binaries under cmd/client and cmd/server.
  - Standardized flag-based config (addresses, identity file, verbosity).

- **New Features**
  - Secure server middleware (optional plaintext via -p) and /keys exposure.
  - Endpoints: /secure (echo greeting) and /stream (chunked streaming).
  - CORS support and reverse proxy to http://localhost:11434 behind secure middleware.
  - Demo client that calls /secure and streams from /stream.

<!-- End of auto-generated description by cubic. -->

