### PR TITLE
Make clients stateless

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,16 @@ import (
   "net/http"
 
   "github.com/tinfoilsh/encrypted-http-body-protocol/client"
+  "github.com/tinfoilsh/encrypted-http-body-protocol/identity"
 )
 
 func main() {
-  tr, err := client.NewTransport("http://localhost:8080")
+  serverIdent, err := identity.FetchFromServer("http://localhost:8080")
   if err != nil {
     log.Fatalf("client exited: %v", err)
   }
 
-  httpClient := &http.Client{Transport: tr}
+  httpClient := &http.Client{Transport: client.NewTransport(serverIdent)}
   resp, err := httpClient.Post("http://localhost:8080/secure", "text/plain", bytes.NewBufferString("hi"))
   if err != nil {
     log.Fatalf("client exited: %v", err)

--- a/client/client.go
+++ b/client/client.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 
@@ -30,65 +29,12 @@ type problemDetails struct {
 
 var _ http.RoundTripper = (*Transport)(nil)
 
-func NewTransport(server string) (*Transport, error) {
-	t := &Transport{
-		httpClient: &http.Client{},
-	}
-
-	if err := t.syncServerPublicKey(server); err != nil {
-		return nil, fmt.Errorf("failed to sync server public key: %v", err)
-	}
-
-	return t, nil
-}
-
-// NewTransportWithConfig creates a new Transport with a pre-fetched HPKE key configuration.
-// The hpkeConfig should be the raw bytes from /.well-known/hpke-keys (RFC 9458 format).
-func NewTransportWithConfig(hpkeConfig []byte) (*Transport, error) {
-	serverIdentity, err := identity.UnmarshalPublicConfig(hpkeConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal public key config: %v", err)
-	}
-
+// NewTransport creates a new Transport with the given server identity.
+func NewTransport(serverIdentity *identity.Identity) *Transport {
 	return &Transport{
 		serverIdentity: serverIdentity,
 		httpClient:     &http.Client{},
-	}, nil
-}
-
-func (t *Transport) syncServerPublicKey(server string) error {
-	keysURL, err := url.Parse(server)
-	if err != nil {
-		return fmt.Errorf("failed to parse server URL: %v", err)
 	}
-	keysURL.Path = protocol.KeysPath
-
-	resp, err := t.httpClient.Get(keysURL.String())
-	if err != nil {
-		return fmt.Errorf("failed to get server public key: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("server returned status %d", resp.StatusCode)
-	}
-
-	if resp.Header.Get("Content-Type") != protocol.KeysMediaType {
-		return fmt.Errorf("server returned invalid content type: %s", resp.Header.Get("Content-Type"))
-	}
-
-	ohttpKeys, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response body: %v", err)
-	}
-
-	serverIdentity, err := identity.UnmarshalPublicConfig(ohttpKeys)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal public key: %v", err)
-	}
-	t.serverIdentity = serverIdentity
-
-	return nil
 }
 
 func (t *Transport) ServerIdentity() *identity.Identity {

--- a/client/client.go
+++ b/client/client.go
@@ -37,10 +37,6 @@ func NewTransport(serverIdentity *identity.Identity) *Transport {
 	}
 }
 
-func (t *Transport) ServerIdentity() *identity.Identity {
-	return t.serverIdentity
-}
-
 // GetSessionRecoveryToken returns the session recovery token from the most
 // recent request that had a body. Returns nil if no token is available (e.g.
 // no request has been made yet, or the last request was bodyless).

--- a/client/client.go
+++ b/client/client.go
@@ -44,7 +44,7 @@ func NewTransport(server string) (*Transport, error) {
 
 // NewTransportWithConfig creates a new Transport with a pre-fetched HPKE key configuration.
 // The hpkeConfig should be the raw bytes from /.well-known/hpke-keys (RFC 9458 format).
-func NewTransportWithConfig(server string, hpkeConfig []byte) (*Transport, error) {
+func NewTransportWithConfig(hpkeConfig []byte) (*Transport, error) {
 	serverIdentity, err := identity.UnmarshalPublicConfig(hpkeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal public key config: %v", err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -62,10 +62,10 @@ func TestSecureClient(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	secureTransport, err := NewTransport(server.URL)
+	serverIdent, err := identity.FetchFromServer(server.URL)
 	assert.NoError(t, err)
 	httpClient := &http.Client{
-		Transport: secureTransport,
+		Transport: NewTransport(serverIdent),
 	}
 
 	t.Run("secure endpoint", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestTransportReturnsErrorOnKeyConfigMismatch(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	transport, err := NewTransport(server.URL)
+	serverIdent, err := identity.FetchFromServer(server.URL)
 	assert.NoError(t, err)
 
 	// Rotate key after client initialization to force a stale-key attempt.
@@ -156,7 +156,7 @@ func TestTransportReturnsErrorOnKeyConfigMismatch(t *testing.T) {
 	active = identityB
 	mu.Unlock()
 
-	httpClient := &http.Client{Transport: transport}
+	httpClient := &http.Client{Transport: NewTransport(serverIdent)}
 	req, err := http.NewRequest("POST", server.URL+"/secure", bytes.NewBuffer([]byte("test")))
 	assert.NoError(t, err)
 
@@ -190,8 +190,9 @@ func TestTransportGetSessionRecoveryToken(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	transport, err := NewTransport(server.URL)
+	serverIdent, err := identity.FetchFromServer(server.URL)
 	assert.NoError(t, err)
+	transport := NewTransport(serverIdent)
 	httpClient := &http.Client{Transport: transport}
 
 	t.Run("nil before any request", func(t *testing.T) {

--- a/cmd/example/client/main.go
+++ b/cmd/example/client/main.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/tinfoilsh/encrypted-http-body-protocol/client"
+	"github.com/tinfoilsh/encrypted-http-body-protocol/identity"
 )
 
 var (
@@ -25,13 +26,13 @@ func main() {
 		log.Debug("Verbose logging enabled")
 	}
 
-	secureTransport, err := client.NewTransport(*serverURL)
+	serverIdent, err := identity.FetchFromServer(*serverURL)
 	if err != nil {
-		log.Fatalf("failed to create secure client: %v", err)
+		log.Fatalf("failed to fetch server identity: %v", err)
 	}
 
 	httpClient := &http.Client{
-		Transport: secureTransport,
+		Transport: client.NewTransport(serverIdent),
 	}
 
 	testSecureEndpoint(httpClient)

--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/tinfoilsh/encrypted-http-body-protocol/client"
+	"github.com/tinfoilsh/encrypted-http-body-protocol/identity"
 )
 
 var (
@@ -32,20 +33,19 @@ func main() {
 		log.Fatalf("URL is required")
 	}
 
-	secureTransport, err := client.NewTransport(url)
+	serverIdent, err := identity.FetchFromServer(url)
 	if err != nil {
-		log.Fatalf("failed to create secure client: %v", err)
+		log.Fatalf("failed to fetch server identity: %v", err)
 	}
 	httpClient := &http.Client{
-		Transport: secureTransport,
+		Transport: client.NewTransport(serverIdent),
 	}
 
-	serverID := secureTransport.ServerIdentity()
 	log.WithFields(log.Fields{
-		"public_key_hex": serverID.MarshalPublicKeyHex(),
-		"hpke_kem":       serverID.KEM().ID(),
-		"hpke_kdf":       serverID.KDF().ID(),
-		"hpke_aead":      serverID.AEAD().ID(),
+		"public_key_hex": serverIdent.MarshalPublicKeyHex(),
+		"hpke_kem":       serverIdent.KEM().ID(),
+		"hpke_kdf":       serverIdent.KDF().ID(),
+		"hpke_aead":      serverIdent.AEAD().ID(),
 	}).Debug("Server Identity")
 
 	var body io.Reader

--- a/identity/crypt.go
+++ b/identity/crypt.go
@@ -13,6 +13,11 @@ import (
 	"github.com/tinfoilsh/encrypted-http-body-protocol/protocol"
 )
 
+// maxChunkLength is the maximum allowed encrypted chunk size (1 MB).
+// The write side uses 8 KB chunks; this limit provides headroom while
+// preventing a malicious peer from triggering a multi-GB allocation.
+const maxChunkLength = 1 << 20
+
 // ClientError represents an error caused by invalid client input
 type ClientError struct {
 	Err error
@@ -187,6 +192,10 @@ func (r *StreamingDecryptReader) Read(p []byte) (n int, err error) {
 		if chunkLen != 0 {
 			break
 		}
+	}
+
+	if chunkLen > maxChunkLength {
+		return 0, NewClientError(fmt.Errorf("chunk length %d exceeds maximum %d", chunkLen, maxChunkLength))
 	}
 
 	// Read encrypted chunk
@@ -481,6 +490,10 @@ func (r *DerivedStreamingDecryptReader) Read(p []byte) (n int, err error) {
 		if chunkLen != 0 {
 			break
 		}
+	}
+
+	if chunkLen > maxChunkLength {
+		return 0, fmt.Errorf("chunk length %d exceeds maximum %d", chunkLen, maxChunkLength)
 	}
 
 	// Read encrypted chunk

--- a/identity/crypt.go
+++ b/identity/crypt.go
@@ -167,24 +167,26 @@ func (r *StreamingDecryptReader) Read(p []byte) (n int, err error) {
 		return n, nil
 	}
 
-	// Read chunk length (4 bytes)
+	// Read chunk length (4 bytes), skipping empty chunks
+	var chunkLen uint32
 	chunkLenBytes := make([]byte, 4)
-	_, err = io.ReadFull(r.reader, chunkLenBytes)
-	if err != nil {
-		if err == io.EOF {
-			r.eof = true
-			return 0, io.EOF
+	for {
+		_, err = io.ReadFull(r.reader, chunkLenBytes)
+		if err != nil {
+			if err == io.EOF {
+				r.eof = true
+				return 0, io.EOF
+			}
+			if err == io.ErrUnexpectedEOF {
+				return 0, NewClientError(fmt.Errorf("invalid chunk length framing: %w", err))
+			}
+			return 0, NewClientError(fmt.Errorf("failed to read chunk length: %w", err))
 		}
-		if err == io.ErrUnexpectedEOF {
-			return 0, NewClientError(fmt.Errorf("invalid chunk length framing: %w", err))
-		}
-		return 0, NewClientError(fmt.Errorf("failed to read chunk length: %w", err))
-	}
 
-	chunkLen := binary.BigEndian.Uint32(chunkLenBytes)
-	if chunkLen == 0 {
-		// Empty chunk, try reading next chunk
-		return r.Read(p)
+		chunkLen = binary.BigEndian.Uint32(chunkLenBytes)
+		if chunkLen != 0 {
+			break
+		}
 	}
 
 	// Read encrypted chunk
@@ -462,20 +464,23 @@ func (r *DerivedStreamingDecryptReader) Read(p []byte) (n int, err error) {
 		return n, nil
 	}
 
-	// Read chunk length (4 bytes)
+	// Read chunk length (4 bytes), skipping empty chunks
+	var chunkLen uint32
 	chunkLenBytes := make([]byte, 4)
-	_, err = io.ReadFull(r.reader, chunkLenBytes)
-	if err != nil {
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
-			r.eof = true
-			return 0, io.EOF
+	for {
+		_, err = io.ReadFull(r.reader, chunkLenBytes)
+		if err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				r.eof = true
+				return 0, io.EOF
+			}
+			return 0, fmt.Errorf("failed to read chunk length: %w", err)
 		}
-		return 0, fmt.Errorf("failed to read chunk length: %w", err)
-	}
 
-	chunkLen := binary.BigEndian.Uint32(chunkLenBytes)
-	if chunkLen == 0 {
-		return r.Read(p) // Skip empty chunks
+		chunkLen = binary.BigEndian.Uint32(chunkLenBytes)
+		if chunkLen != 0 {
+			break
+		}
 	}
 
 	// Read encrypted chunk

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -6,8 +6,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/tinfoilsh/encrypted-http-body-protocol/protocol"
 	"golang.org/x/crypto/cryptobyte"
@@ -231,6 +236,51 @@ func UnmarshalPublicConfig(data []byte) (*Identity, error) {
 		pk:   pk,
 		sk:   nil, // public key only
 	}, nil
+}
+
+const (
+	// maxKeyConfigSize bounds the key configuration response body read from the
+	// server, preventing a malicious endpoint from forcing a large allocation.
+	maxKeyConfigSize = 1 << 16
+
+	// keyFetchTimeout bounds how long FetchFromServer waits on the key endpoint.
+	keyFetchTimeout = 30 * time.Second
+)
+
+// FetchFromServer fetches and parses the server's public identity from its HPKE key endpoint.
+func FetchFromServer(serverURL string) (*Identity, error) {
+	keysURL, err := url.Parse(serverURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse server URL: %v", err)
+	}
+	keysURL.Path = protocol.KeysPath
+
+	httpClient := &http.Client{Timeout: keyFetchTimeout}
+	resp, err := httpClient.Get(keysURL.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch server public key: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned status %d", resp.StatusCode)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	mediaType, _, parseErr := mime.ParseMediaType(contentType)
+	if parseErr != nil {
+		mediaType = strings.ToLower(contentType)
+	}
+	if !strings.EqualFold(mediaType, protocol.KeysMediaType) {
+		return nil, fmt.Errorf("invalid content type: %s", contentType)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxKeyConfigSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	return UnmarshalPublicConfig(body)
 }
 
 // Export returns a JSON representation of the identity

--- a/js/README.md
+++ b/js/README.md
@@ -21,13 +21,14 @@ All HPKE key operations use [`@noble/curves`](https://github.com/paulmillr/noble
 ## Quick Start
 
 ```javascript
-import { createTransport } from 'ehbp';
+import { Identity, Transport } from 'ehbp';
 
-// Create transport (fetches server public key automatically)
-const transport = await createTransport('https://example.com');
+// Fetch server identity (standalone usage without attestation)
+const identity = await Identity.fetchFromServer('https://example.com');
+const transport = new Transport(identity);
 
 // Make encrypted requests - works like fetch()
-const response = await transport.post('/api/data', JSON.stringify({ message: 'hello' }), {
+const response = await transport.post('https://example.com/api/data', JSON.stringify({ message: 'hello' }), {
   headers: { 'Content-Type': 'application/json' }
 });
 
@@ -36,12 +37,18 @@ const data = await response.json();
 
 ## API
 
-### `createTransport(serverURL: string): Promise<Transport>`
+### `new Transport(serverIdentity: Identity)`
 
-Creates a transport that automatically encrypts requests and decrypts responses.
+Creates a transport that encrypts requests and decrypts responses using the given server identity.
 
 ```javascript
-const transport = await createTransport('https://example.com');
+// With an attested key (recommended for production)
+const identity = await Identity.fromPublicKeyHex(attestedPublicKey);
+const transport = new Transport(identity);
+
+// Or fetch directly (standalone usage, no verification)
+const identity = await Identity.fetchFromServer('https://example.com');
+const transport = new Transport(identity);
 ```
 
 ### `transport.request(input, init?): Promise<Response>`
@@ -69,10 +76,11 @@ await transport.delete('/users/123');
 
 ```html
 <script type="module">
-  import { createTransport } from './dist/browser.js';
+  import { Identity, Transport } from './dist/browser.js';
 
-  const transport = await createTransport('https://example.com');
-  const response = await transport.post('/api', 'Hello!');
+  const identity = await Identity.fetchFromServer('https://example.com');
+  const transport = new Transport(identity);
+  const response = await transport.post('https://example.com/api', 'Hello!');
   console.log(await response.text());
 </script>
 ```

--- a/js/README.md
+++ b/js/README.md
@@ -45,7 +45,9 @@ Creates a transport that encrypts requests and decrypts responses using the give
 // With an attested key (recommended for production)
 const identity = await Identity.fromPublicKeyHex(attestedPublicKey);
 const transport = new Transport(identity);
+```
 
+```javascript
 // Or fetch directly (standalone usage, no verification)
 const identity = await Identity.fetchFromServer('https://example.com');
 const transport = new Transport(identity);

--- a/js/examples/chat.html
+++ b/js/examples/chat.html
@@ -126,7 +126,7 @@
     </div>
 
     <script type="module">
-        import { createTransport } from '../dist/browser.js';
+        import { Identity, Transport } from '../dist/browser.js';
 
         const serverUrl = 'http://localhost:8443';
 
@@ -135,7 +135,8 @@
 
         async function initializeClient() {
             try {
-                transport = await createTransport(serverUrl);
+                const identity = await Identity.fetchFromServer(serverUrl);
+                transport = new Transport(identity);
                 return true;
             } catch (error) {
                 console.error('Failed to connect:', error.message);

--- a/js/examples/example.ts
+++ b/js/examples/example.ts
@@ -4,7 +4,7 @@
  * Example usage of the EHBP JavaScript client
  */
 
-import { createTransport } from '../dist/esm/index.js';
+import { Identity, Transport } from '../dist/esm/index.js';
 
 async function main() {
   console.log('EHBP JavaScript Client Example');
@@ -14,9 +14,10 @@ async function main() {
     // Create transport (this will fetch server public key)
     console.log('Creating transport...');
     const serverURL = 'http://localhost:8080'; // Adjust as needed
-    const transport = await createTransport(serverURL);
+    const identity = await Identity.fetchFromServer(serverURL);
+    const transport = new Transport(identity);
     console.log('Transport created successfully');
-    console.log('Server public key:', await transport.getServerPublicKeyHex());
+    console.log('Server public key:', await identity.getPublicKeyHex());
 
     // Example 1: GET request to secure endpoint
     console.log('\n--- GET Request ---');

--- a/js/examples/test.html
+++ b/js/examples/test.html
@@ -122,7 +122,7 @@
     </div>
 
     <script type="module">
-        import { createTransport } from '../dist/browser.js';
+        import { Identity, Transport } from '../dist/browser.js';
 
         let transport = null;
 
@@ -130,7 +130,8 @@
             try {
                 updateStatus('serverStatus', 'info', 'Initializing client...');
                 const serverUrl = document.getElementById('serverUrl').value;
-                transport = await createTransport(serverUrl);
+                const identity = await Identity.fetchFromServer(serverUrl);
+                transport = new Transport(identity);
                 updateStatus('serverStatus', 'success', `Connected to ${serverUrl}`);
                 return true;
             } catch (error) {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -3,7 +3,6 @@ import { extractSessionRecoveryToken, decryptResponseWithToken } from './identit
 import type { SessionRecoveryToken } from './identity.js';
 import { PROTOCOL } from './protocol.js';
 import { KeyConfigMismatchError, ProtocolError } from './errors.js';
-import type { Key } from 'hpke';
 
 interface ProblemDetails {
   type?: string;
@@ -51,27 +50,6 @@ export class Transport {
         typeof problem.title === 'string' ? problem.title : undefined
       );
     }
-  }
-
-  /**
-   * Get the server identity
-   */
-  getServerIdentity(): Identity {
-    return this.serverIdentity;
-  }
-
-  /**
-   * Get the server public key
-   */
-  getServerPublicKey(): Key {
-    return this.serverIdentity.getPublicKey();
-  }
-
-  /**
-   * Get the server public key as hex string
-   */
-  async getServerPublicKeyHex(): Promise<string> {
-    return this.serverIdentity.getPublicKeyHex();
   }
 
   /**

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -30,32 +30,6 @@ export class Transport {
     return this._lastSessionRecoveryToken;
   }
 
-  /**
-   * Create a new transport by fetching server public key.
-   */
-  static async create(serverURL: string): Promise<Transport> {
-    const url = new URL(serverURL);
-    const serverHost = url.host;
-
-    // Fetch server public key
-    const keysURL = new URL(PROTOCOL.KEYS_PATH, serverURL);
-    const response = await fetch(keysURL.toString());
-
-    if (!response.ok) {
-      throw new Error(`Failed to get server public key: ${response.status}`);
-    }
-
-    const contentType = response.headers.get('content-type');
-    if (contentType !== PROTOCOL.KEYS_MEDIA_TYPE) {
-      throw new Error(`Invalid content type: ${contentType}`);
-    }
-
-    const keysData = new Uint8Array(await response.arrayBuffer());
-    const serverIdentity = await Identity.unmarshalPublicConfig(keysData);
-
-    return new Transport(serverIdentity, serverHost);
-  }
-
   private static isProblemJSONContentType(contentType: string | null): boolean {
     if (!contentType) {
       return false;
@@ -210,11 +184,4 @@ export class Transport {
   async delete(url: string | URL, init?: RequestInit): Promise<Response> {
     return this.request(url, { ...init, method: 'DELETE' });
   }
-}
-
-/**
- * Create a new transport instance.
- */
-export async function createTransport(serverURL: string): Promise<Transport> {
-  return Transport.create(serverURL);
 }

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -15,12 +15,10 @@ interface ProblemDetails {
  */
 export class Transport {
   private serverIdentity: Identity;
-  private serverHost: string;
   private _lastSessionRecoveryToken?: SessionRecoveryToken;
 
-  constructor(serverIdentity: Identity, serverHost: string) {
+  constructor(serverIdentity: Identity) {
     this.serverIdentity = serverIdentity;
-    this.serverHost = serverHost;
   }
 
   getSessionRecoveryToken(): SessionRecoveryToken {
@@ -99,7 +97,7 @@ export class Transport {
       requestBody = init?.body || null;
     }
 
-    // Create the URL with correct host
+    // Parse request parameters
     let url: URL;
     let method: string;
     let headers: HeadersInit;
@@ -113,8 +111,6 @@ export class Transport {
       method = init?.method || 'GET';
       headers = init?.headers || {};
     }
-
-    url.host = this.serverHost;
 
     const request = new Request(url.toString(), {
       method,

--- a/js/src/identity.ts
+++ b/js/src/identity.ts
@@ -220,7 +220,8 @@ export class Identity {
       throw new ProtocolError(`Failed to fetch server public key: HTTP ${response.status}`);
     }
     const contentType = response.headers.get('content-type');
-    if (contentType !== PROTOCOL.KEYS_MEDIA_TYPE) {
+    const mediaType = contentType?.split(';', 1)[0]?.trim().toLowerCase() ?? '';
+    if (mediaType !== PROTOCOL.KEYS_MEDIA_TYPE) {
       throw new ProtocolError(
         `Invalid content type from key endpoint: expected "${PROTOCOL.KEYS_MEDIA_TYPE}", got "${contentType}"`
       );

--- a/js/src/identity.ts
+++ b/js/src/identity.ts
@@ -208,6 +208,28 @@ export class Identity {
   }
 
   /**
+   * Fetch and parse the server's public identity from its HPKE key endpoint.
+   *
+   * This fetches without out-of-band verification. For production use,
+   * make sure this is sufficient or prefer using an attested key.
+   */
+  static async fetchFromServer(serverURL: string): Promise<Identity> {
+    const keysURL = new URL(PROTOCOL.KEYS_PATH, serverURL);
+    const response = await fetch(keysURL.toString());
+    if (!response.ok) {
+      throw new ProtocolError(`Failed to fetch server public key: HTTP ${response.status}`);
+    }
+    const contentType = response.headers.get('content-type');
+    if (contentType !== PROTOCOL.KEYS_MEDIA_TYPE) {
+      throw new ProtocolError(
+        `Invalid content type from key endpoint: expected "${PROTOCOL.KEYS_MEDIA_TYPE}", got "${contentType}"`
+      );
+    }
+    const keysData = new Uint8Array(await response.arrayBuffer());
+    return Identity.unmarshalPublicConfig(keysData);
+  }
+
+  /**
    * Create an Identity from a raw public key hex string.
    * Uses the default cipher suite (X25519/HKDF-SHA256/AES-256-GCM).
    *

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -9,7 +9,7 @@
 export { Identity } from './identity.js';
 export type { RequestContext, SessionRecoveryToken } from './identity.js';
 export { extractSessionRecoveryToken, decryptResponseWithToken, serializeSessionRecoveryToken, deserializeSessionRecoveryToken } from './identity.js';
-export { Transport, createTransport } from './client.js';
+export { Transport } from './client.js';
 export { PROTOCOL, HPKE_CONFIG } from './protocol.js';
 export {
   EhbpError,

--- a/js/src/test/client.test.ts
+++ b/js/src/test/client.test.ts
@@ -159,7 +159,7 @@ describe('Transport', () => {
 
     const testName = 'Integration Test User';
 
-    const serverPubKeyHex = await transport.getServerPublicKeyHex();
+    const serverPubKeyHex = await identity.getPublicKeyHex();
     assert.strictEqual(serverPubKeyHex.length, 64, 'Server public key should be 64 hex chars (32 bytes)');
 
     // Make actual POST request to /secure endpoint

--- a/js/src/test/client.test.ts
+++ b/js/src/test/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert';
-import { Identity, Transport, createTransport, KeyConfigMismatchError } from '../index.js';
+import { Identity, Transport, KeyConfigMismatchError } from '../index.js';
 import { PROTOCOL } from '../protocol.js';
 import { CipherSuite } from 'hpke';
 import { KEM_DHKEM_X25519_HKDF_SHA256, KDF_HKDF_SHA256, AEAD_AES_256_GCM } from '@panva/hpke-noble';
@@ -94,10 +94,7 @@ describe('Transport', () => {
   });
 
   it('should create transport with server public key', () => {
-    const transport = new Transport(
-      serverIdentity,
-      'localhost:8080'
-    );
+    const transport = new Transport(serverIdentity);
 
     assert(transport instanceof Transport, 'Should create transport instance');
   });
@@ -157,7 +154,8 @@ describe('Transport', () => {
       return;
     }
 
-    const transport = await createTransport(serverURL);
+    const identity = await Identity.fetchFromServer(serverURL);
+    const transport = new Transport(identity);
 
     const testName = 'Integration Test User';
 
@@ -212,7 +210,8 @@ describe('Transport', () => {
     }) as typeof fetch;
 
     try {
-      const transport = await createTransport(serverURL);
+      const identity = await Identity.fetchFromServer(serverURL);
+      const transport = new Transport(identity);
       await assert.rejects(
         () => transport.post(`${serverURL}/secure`, 'hello'),
         (err: unknown) => {
@@ -228,7 +227,7 @@ describe('Transport', () => {
 
   it('should not throw KeyConfigMismatchError for 422 without problem+json', async () => {
     const serverIdentity = await Identity.generate();
-    const transport = new Transport(serverIdentity, 'server.test');
+    const transport = new Transport(serverIdentity);
 
     const originalFetch = globalThis.fetch;
 
@@ -257,7 +256,7 @@ describe('Transport', () => {
 
   it('should encrypt, send, and decrypt a full round-trip', async () => {
     const serverIdentity = await Identity.generate();
-    const transport = new Transport(serverIdentity, 'server.test');
+    const transport = new Transport(serverIdentity);
 
     const originalFetch = globalThis.fetch;
 

--- a/js/src/test/session-recovery.test.ts
+++ b/js/src/test/session-recovery.test.ts
@@ -554,7 +554,7 @@ describe('Session Recovery Token', () => {
     it('should throw before any request is made', async () => {
       const { identity } = await generateTestKeys();
       const { Transport } = await import('../client.js');
-      const transport = new Transport(identity, 'server.test');
+      const transport = new Transport(identity);
 
       assert.throws(
         () => transport.getSessionRecoveryToken(),
@@ -565,7 +565,7 @@ describe('Session Recovery Token', () => {
     it('should return a working token after a request', async () => {
       const { identity, privateKey } = await generateTestKeys();
       const { Transport } = await import('../client.js');
-      const transport = new Transport(identity, 'server.test');
+      const transport = new Transport(identity);
 
       const originalFetch = globalThis.fetch;
 
@@ -591,7 +591,7 @@ describe('Session Recovery Token', () => {
     it('should update the token on each new request', async () => {
       const { identity, privateKey } = await generateTestKeys();
       const { Transport } = await import('../client.js');
-      const transport = new Transport(identity, 'server.test');
+      const transport = new Transport(identity);
 
       const originalFetch = globalThis.fetch;
 
@@ -621,7 +621,7 @@ describe('Session Recovery Token', () => {
     it('should clear the token for bodyless requests', async () => {
       const { identity, privateKey } = await generateTestKeys();
       const { Transport } = await import('../client.js');
-      const transport = new Transport(identity, 'server.test');
+      const transport = new Transport(identity);
 
       const originalFetch = globalThis.fetch;
 

--- a/js/src/test/streaming.integration.ts
+++ b/js/src/test/streaming.integration.ts
@@ -7,7 +7,7 @@
  * Run with: npm run test:integration
  */
 
-import { createTransport } from '../index.js';
+import { Identity, Transport } from '../index.js';
 
 async function streamingIntegrationTest() {
   console.log('EHBP Streaming Integration Test');
@@ -17,7 +17,8 @@ async function streamingIntegrationTest() {
     // Create transport
     console.log('Creating transport...');
     const serverURL = 'http://localhost:8080';
-    const transport = await createTransport(serverURL);
+    const identity = await Identity.fetchFromServer(serverURL);
+    const transport = new Transport(identity, new URL(serverURL).host);
     console.log('Transport created');
 
     // Test 1: GET streaming (unencrypted - bodyless request)

--- a/js/src/test/streaming.integration.ts
+++ b/js/src/test/streaming.integration.ts
@@ -18,7 +18,7 @@ async function streamingIntegrationTest() {
     console.log('Creating transport...');
     const serverURL = 'http://localhost:8080';
     const identity = await Identity.fetchFromServer(serverURL);
-    const transport = new Transport(identity, new URL(serverURL).host);
+    const transport = new Transport(identity);
     console.log('Transport created');
 
     // Test 1: GET streaming (unencrypted - bodyless request)

--- a/swift/Sources/EHBP/Client.swift
+++ b/swift/Sources/EHBP/Client.swift
@@ -3,7 +3,6 @@ import Foundation
 /// Streaming EHBP client for making encrypted HTTP requests
 public final class EHBPClient: @unchecked Sendable {
     private let identity: Identity
-    private let baseURL: String
     private let session: URLSession
     private let tokenLock = NSLock()
     private var _lastSessionRecoveryToken: SessionRecoveryToken?
@@ -11,24 +10,10 @@ public final class EHBPClient: @unchecked Sendable {
     /// Creates a new EHBP client
     ///
     /// - Parameters:
-    ///   - baseURL: Base URL for the server (e.g., "https://api.example.com")
-    ///   - publicKey: Server's X25519 public key (32 bytes)
+    ///   - identity: Server identity (public key) for encryption
     ///   - session: URLSession to use (defaults to shared)
-    public init(baseURL: String, publicKey: Data, session: URLSession = .shared) throws {
-        self.identity = try Identity(publicKeyBytes: publicKey)
-        self.baseURL = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
-        self.session = session
-    }
-
-    /// Creates a new EHBP client from RFC 9458 key configuration
-    ///
-    /// - Parameters:
-    ///   - baseURL: Base URL for the server
-    ///   - config: RFC 9458 key configuration data
-    ///   - session: URLSession to use (defaults to shared)
-    public init(baseURL: String, config: Data, session: URLSession = .shared) throws {
-        self.identity = try Identity(config: config)
-        self.baseURL = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
+    public init(identity: Identity, session: URLSession = .shared) {
+        self.identity = identity
         self.session = session
     }
 
@@ -49,17 +34,16 @@ public final class EHBPClient: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - method: HTTP method
-    ///   - path: URL path (will be appended to baseURL)
+    ///   - url: Full URL string (e.g., "https://api.example.com/v1/chat")
     ///   - headers: Additional headers to include
     ///   - body: Request body (will be encrypted)
     /// - Returns: Decrypted response data
     public func request(
         method: String,
-        path: String,
+        url urlString: String,
         headers: [String: String] = [:],
         body: Data?
     ) async throws -> (data: Data, response: HTTPURLResponse) {
-        let urlString = baseURL + path
         guard let url = URL(string: urlString) else {
             throw EHBPError.invalidInput("invalid URL: \(urlString)")
         }
@@ -129,17 +113,16 @@ public final class EHBPClient: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - method: HTTP method
-    ///   - path: URL path
+    ///   - url: Full URL string
     ///   - headers: Additional headers
     ///   - body: Request body (will be encrypted)
     /// - Returns: AsyncThrowingStream of decrypted response chunks
     public func requestStream(
         method: String,
-        path: String,
+        url urlString: String,
         headers: [String: String] = [:],
         body: Data?
     ) async throws -> (stream: AsyncThrowingStream<Data, Error>, response: HTTPURLResponse) {
-        let urlString = baseURL + path
         guard let url = URL(string: urlString) else {
             throw EHBPError.invalidInput("invalid URL: \(urlString)")
         }

--- a/swift/Sources/EHBP/Client.swift
+++ b/swift/Sources/EHBP/Client.swift
@@ -217,6 +217,10 @@ public final class EHBPClient: @unchecked Sendable {
                                 continue
                             }
 
+                            guard chunkLength <= EHBPConstants.maxChunkLength else {
+                                throw EHBPError.invalidResponse("chunk length \(chunkLength) exceeds maximum \(EHBPConstants.maxChunkLength)")
+                            }
+
                             guard buffer.count >= 4 + chunkLength else {
                                 break
                             }
@@ -244,7 +248,6 @@ public final class EHBPClient: @unchecked Sendable {
 
         return (stream, httpResponse)
     }
-
 }
 
 // MARK: - Data Extensions

--- a/swift/Sources/EHBP/EHBP.swift
+++ b/swift/Sources/EHBP/EHBP.swift
@@ -6,10 +6,11 @@
 //
 // Usage:
 //
-//     let client = try EHBPClient(baseURL: "https://api.example.com", publicKey: serverPublicKey)
+//     let identity = try Identity(publicKeyBytes: serverPublicKey)
+//     let client = EHBPClient(identity: identity)
 //     let (data, response) = try await client.request(
 //         method: "POST",
-//         path: "/v1/chat/completions",
+//         url: "https://api.example.com/v1/chat/completions",
 //         headers: ["Authorization": "Bearer \(apiKey)"],
 //         body: requestBody
 //     )

--- a/swift/Sources/EHBP/Identity.swift
+++ b/swift/Sources/EHBP/Identity.swift
@@ -104,6 +104,10 @@ public func decryptResponseBody(
             continue
         }
 
+        guard chunkLength <= EHBPConstants.maxChunkLength else {
+            throw EHBPError.invalidResponse("chunk length \(chunkLength) exceeds maximum \(EHBPConstants.maxChunkLength)")
+        }
+
         guard offset + chunkLength <= encryptedData.count else {
             throw EHBPError.invalidResponse("incomplete chunk at offset \(offset)")
         }

--- a/swift/Sources/EHBP/Protocol.swift
+++ b/swift/Sources/EHBP/Protocol.swift
@@ -55,4 +55,9 @@ public enum EHBPConstants {
 
     /// Label for deriving response nonce
     public static let responseNonceLabel = "nonce"
+
+    /// Maximum allowed encrypted chunk size (1 MB).
+    /// The write side uses small chunks; this limit provides headroom while
+    /// preventing a malicious peer from triggering a multi-GB allocation.
+    public static let maxChunkLength = 1 << 20
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Made the clients stateless across Go/JS/Swift by moving key fetch to `Identity.fetchFromServer` and removing URL pinning/host rewriting. Hardened streaming decryption with iterative parsing and a 1 MB chunk limit enforced in Go and Swift; key endpoint reads are now bounded and content types are parsed with media-type parameters.

- **Refactors**
  - Go/JS `Transport` now only takes an `Identity`; no URL pinning.
  - Removed `createTransport`/`Transport.create`; callers fetch identity via `Identity.fetchFromServer`.
  - Requests now require absolute URLs in JS and Swift; removed JS host rewriting.
  - Go: added `Identity.FetchFromServer(serverURL)` with media-type parameter parsing, a 30s timeout, and a 64 KB body limit.
  - Security: replaced recursive empty-chunk handling with loops; reject chunks >1 MB in Go and Swift.
  - Removed JS pass-through getters for server public key; removed Go `Transport.ServerIdentity()`. Use `Identity` directly.
  - Docs/examples/tests updated.

- **Migration**
  - JS:
    - Replace `createTransport('https://example.com')` with:
      - `const identity = await Identity.fetchFromServer('https://example.com');`
      - `const transport = new Transport(identity);`
    - Use absolute URLs, e.g., `transport.post('https://example.com/api', body)`.
    - Get the public key via `identity.getPublicKeyHex()`.
  - Go:
    - `serverIdent, _ := identity.FetchFromServer("https://example.com")`
    - `httpClient := &http.Client{Transport: client.NewTransport(serverIdent)}`
    - Use absolute URLs; access server key info from `serverIdent` (no `ServerIdentity()`).
  - Swift:
    - `let ident = try Identity(publicKeyBytes: ...)`
    - `let client = EHBPClient(identity: ident)`
    - Pass full URL strings to request methods.

<sup>Written for commit 5ecb904aff41860090d08eb39f8262bfb268d9a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

