### PR TITLE
feat: replace circl/hpke with native crypto/hpke

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -154,7 +154,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	var token *identity.SessionRecoveryToken
 	if reqCtx != nil {
-		token = identity.ExtractSessionRecoveryToken(reqCtx)
+		token, err = identity.ExtractSessionRecoveryToken(reqCtx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract session recovery token: %v", err)
+		}
 	}
 
 	// Clear token for bodyless requests immediately

--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -40,9 +40,12 @@ func main() {
 		Transport: secureTransport,
 	}
 
+	serverID := secureTransport.ServerIdentity()
 	log.WithFields(log.Fields{
-		"public_key_hex": secureTransport.ServerIdentity().MarshalPublicKeyHex(),
-		"hpke_suite":     secureTransport.ServerIdentity().Suite(),
+		"public_key_hex": serverID.MarshalPublicKeyHex(),
+		"hpke_kem":       serverID.KEM().ID(),
+		"hpke_kdf":       serverID.KDF().ID(),
+		"hpke_aead":      serverID.AEAD().ID(),
 	}).Debug("Server Identity")
 
 	var body io.Reader

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/tinfoilsh/encrypted-http-body-protocol
 
-go 1.26.0
+go 1.26
 
 require (
-	github.com/cloudflare/circl v1.6.3
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
-github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -1,31 +1,36 @@
 package identity
 
 import (
+	"crypto/ecdh"
+	"crypto/hpke"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 
-	"github.com/cloudflare/circl/hpke"
-	"github.com/cloudflare/circl/kem"
 	"github.com/tinfoilsh/encrypted-http-body-protocol/protocol"
 	"golang.org/x/crypto/cryptobyte"
 )
 
 type Identity struct {
-	pk    kem.PublicKey
-	sk    kem.PrivateKey
-	suite hpke.Suite
+	pk   hpke.PublicKey
+	sk   hpke.PrivateKey
+	kem  hpke.KEM
+	kdf  hpke.KDF
+	aead hpke.AEAD
 }
 
-func (i *Identity) Suite() hpke.Suite {
-	return i.suite
+func (i *Identity) KEM() hpke.KEM {
+	return i.kem
 }
 
-func (i *Identity) KEMScheme() kem.Scheme {
-	kemID, _, _ := i.suite.Params()
-	return kemID.Scheme()
+func (i *Identity) KDF() hpke.KDF {
+	return i.kdf
+}
+
+func (i *Identity) AEAD() hpke.AEAD {
+	return i.aead
 }
 
 // IdentityStore is a serializable representation of an Identity
@@ -33,27 +38,30 @@ type IdentityStore struct {
 	PublicKey []byte
 	SecretKey []byte
 
-	// HPKE suite parameters
-	KEM  hpke.KEM
-	KDF  hpke.KDF
-	AEAD hpke.AEAD
+	// HPKE suite parameters (stored as RFC 9180 identifiers)
+	KEM  uint16
+	KDF  uint16
+	AEAD uint16
 }
 
 // NewIdentity generates a new key pair
 func NewIdentity() (*Identity, error) {
-	i := &Identity{
-		suite: hpke.NewSuite(hpke.KEM_X25519_HKDF_SHA256, hpke.KDF_HKDF_SHA256, hpke.AEAD_AES256GCM),
-	}
+	kem := hpke.DHKEM(ecdh.X25519())
+	kdf := hpke.HKDFSHA256()
+	aead := hpke.AES256GCM()
 
-	kemID, _, _ := i.suite.Params()
-
-	var err error
-	i.pk, i.sk, err = kemID.Scheme().GenerateKeyPair()
+	sk, err := kem.GenerateKey()
 	if err != nil {
 		return nil, err
 	}
 
-	return i, nil
+	return &Identity{
+		pk:   sk.PublicKey(),
+		sk:   sk,
+		kem:  kem,
+		kdf:  kdf,
+		aead: aead,
+	}, nil
 }
 
 // FromFile loads an identity from a file or creates a new one if it doesn't exist
@@ -85,22 +93,18 @@ func FromFile(filename string) (*Identity, error) {
 }
 
 // PublicKey returns the public key of an identity
-func (i *Identity) PublicKey() kem.PublicKey {
+func (i *Identity) PublicKey() hpke.PublicKey {
 	return i.pk
 }
 
 // PrivateKey returns the private key of an identity
-func (i *Identity) PrivateKey() kem.PrivateKey {
+func (i *Identity) PrivateKey() hpke.PrivateKey {
 	return i.sk
 }
 
 // MarshalPublicKey returns a binary representation of the public key
 func (i *Identity) MarshalPublicKey() []byte {
-	pkM, err := i.pk.MarshalBinary()
-	if err != nil {
-		panic("code error: invalid pk: " + err.Error())
-	}
-	return pkM
+	return i.pk.Bytes()
 }
 
 // MarshalPublicKeyHex returns a hex string representation of the public key
@@ -110,20 +114,15 @@ func (i *Identity) MarshalPublicKeyHex() string {
 
 // MarshalConfig returns a binary representation of the identity compatible with RFC9458 application/ohttp-keys
 func (i *Identity) MarshalConfig() ([]byte, error) {
-	pkBytes, err := i.pk.MarshalBinary()
-	if err != nil {
-		return nil, fmt.Errorf("marshal public key: %v", err)
-	}
-
-	kemID, kdfID, aeadID := i.suite.Params()
+	pkBytes := i.pk.Bytes()
 
 	b := cryptobyte.NewBuilder(nil)
 	b.AddUint8(0) // Key ID
-	b.AddUint16(uint16(kemID))
+	b.AddUint16(i.kem.ID())
 	b.AddBytes(pkBytes)
 	b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
-		b.AddUint16(uint16(kdfID))
-		b.AddUint16(uint16(aeadID))
+		b.AddUint16(i.kdf.ID())
+		b.AddUint16(i.aead.ID())
 	})
 
 	return b.Bytes()
@@ -140,6 +139,24 @@ func (i *Identity) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(configs)
 }
 
+// kemPublicKeySize returns the public key size for a given KEM ID per RFC 9180.
+func kemPublicKeySize(kemID uint16) (int, error) {
+	switch kemID {
+	case 0x0010: // DHKEM(P-256, HKDF-SHA256)
+		return 65, nil
+	case 0x0011: // DHKEM(P-384, HKDF-SHA384)
+		return 97, nil
+	case 0x0012: // DHKEM(P-521, HKDF-SHA512)
+		return 133, nil
+	case 0x0020: // DHKEM(X25519, HKDF-SHA256)
+		return 32, nil
+	case 0x0021: // DHKEM(X448, HKDF-SHA512)
+		return 56, nil
+	default:
+		return 0, fmt.Errorf("unknown KEM ID: 0x%04x", kemID)
+	}
+}
+
 // UnmarshalPublicConfig unmarshals a keys config into an identity
 //
 // Per https://github.com/chris-wood/ohttp-go/blob/main/ohttp.go
@@ -153,13 +170,18 @@ func UnmarshalPublicConfig(data []byte) (*Identity, error) {
 		return nil, fmt.Errorf("invalid config")
 	}
 
-	kem := hpke.KEM(kemID)
-	if !kem.IsValid() {
-		return nil, fmt.Errorf("invalid KEM")
+	kem, err := hpke.NewKEM(kemID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid KEM: %w", err)
 	}
 
-	publicKeyBytes := make([]byte, kem.Scheme().PublicKeySize())
-	if !s.ReadBytes(&publicKeyBytes, len(publicKeyBytes)) {
+	pkSize, err := kemPublicKeySize(kemID)
+	if err != nil {
+		return nil, fmt.Errorf("unsupported KEM: %w", err)
+	}
+
+	publicKeyBytes := make([]byte, pkSize)
+	if !s.ReadBytes(&publicKeyBytes, pkSize) {
 		return nil, fmt.Errorf("invalid config")
 	}
 
@@ -167,7 +189,12 @@ func UnmarshalPublicConfig(data []byte) (*Identity, error) {
 	if !s.ReadUint16LengthPrefixed(&cipherSuites) {
 		return nil, fmt.Errorf("invalid config")
 	}
-	var suites []hpke.Suite
+
+	type cipherSuite struct {
+		kdf  hpke.KDF
+		aead hpke.AEAD
+	}
+	var suites []cipherSuite
 	for !cipherSuites.Empty() {
 		var kdfID uint16
 		var aeadID uint16
@@ -176,20 +203,19 @@ func UnmarshalPublicConfig(data []byte) (*Identity, error) {
 			return nil, fmt.Errorf("invalid config")
 		}
 
-		// Sanity check validity of the KDF and AEAD values
-		kdf := hpke.KDF(kdfID)
-		if !kdf.IsValid() {
-			return nil, fmt.Errorf("invalid KDF")
+		kdf, err := hpke.NewKDF(kdfID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid KDF: %w", err)
 		}
-		aead := hpke.AEAD(aeadID)
-		if !aead.IsValid() {
-			return nil, fmt.Errorf("invalid AEAD")
+		aead, err := hpke.NewAEAD(aeadID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid AEAD: %w", err)
 		}
 
-		suites = append(suites, hpke.NewSuite(kem, kdf, aead))
+		suites = append(suites, cipherSuite{kdf: kdf, aead: aead})
 	}
 
-	pk, err := kem.Scheme().UnmarshalBinaryPublicKey(publicKeyBytes)
+	pk, err := kem.NewPublicKey(publicKeyBytes)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal public key: %v", err)
 	}
@@ -199,31 +225,28 @@ func UnmarshalPublicConfig(data []byte) (*Identity, error) {
 	}
 
 	return &Identity{
-		suite: suites[0],
-		pk:    pk,
-		sk:    nil, // public key only
+		kem:  kem,
+		kdf:  suites[0].kdf,
+		aead: suites[0].aead,
+		pk:   pk,
+		sk:   nil, // public key only
 	}, nil
 }
 
 // Export returns a JSON representation of the identity
 func (i *Identity) Export() ([]byte, error) {
-	pkM, err := i.pk.MarshalBinary()
+	pkBytes := i.pk.Bytes()
+	skBytes, err := i.sk.Bytes()
 	if err != nil {
 		return nil, err
 	}
-	skM, err := i.sk.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
-
-	kemID, kdfID, aeadID := i.suite.Params()
 
 	return json.Marshal(IdentityStore{
-		PublicKey: pkM,
-		SecretKey: skM,
-		KEM:       kemID,
-		KDF:       kdfID,
-		AEAD:      aeadID,
+		PublicKey: pkBytes,
+		SecretKey: skBytes,
+		KEM:       i.kem.ID(),
+		KDF:       i.kdf.ID(),
+		AEAD:      i.aead.ID(),
 	})
 }
 
@@ -238,16 +261,29 @@ func Import(identityJSONBytes []byte) (*Identity, error) {
 		return nil, fmt.Errorf("invalid identity HPKE configuration")
 	}
 
-	suite := hpke.NewSuite(identityStore.KEM, identityStore.KDF, identityStore.AEAD)
+	kem, err := hpke.NewKEM(identityStore.KEM)
+	if err != nil {
+		return nil, fmt.Errorf("invalid KEM: %w", err)
+	}
+	kdf, err := hpke.NewKDF(identityStore.KDF)
+	if err != nil {
+		return nil, fmt.Errorf("invalid KDF: %w", err)
+	}
+	aead, err := hpke.NewAEAD(identityStore.AEAD)
+	if err != nil {
+		return nil, fmt.Errorf("invalid AEAD: %w", err)
+	}
 
 	var i Identity
-	i.suite = suite
-	var err error
-	i.pk, err = i.KEMScheme().UnmarshalBinaryPublicKey(identityStore.PublicKey)
+	i.kem = kem
+	i.kdf = kdf
+	i.aead = aead
+
+	i.pk, err = kem.NewPublicKey(identityStore.PublicKey)
 	if err != nil {
 		return nil, err
 	}
-	i.sk, err = i.KEMScheme().UnmarshalBinaryPrivateKey(identityStore.SecretKey)
+	i.sk, err = kem.NewPrivateKey(identityStore.SecretKey)
 	if err != nil {
 		return nil, err
 	}

--- a/identity/session_recovery.go
+++ b/identity/session_recovery.go
@@ -54,14 +54,17 @@ func (t *SessionRecoveryToken) UnmarshalJSON(data []byte) error {
 // ExtractSessionRecoveryToken exports the HPKE shared secret from a
 // RequestContext and returns a serializable token that can decrypt the
 // corresponding response independently.
-func ExtractSessionRecoveryToken(ctx *RequestContext) *SessionRecoveryToken {
-	exportedSecret := ctx.Sealer.Export([]byte(ExportLabel), uint(ExportLength))
+func ExtractSessionRecoveryToken(ctx *RequestContext) (*SessionRecoveryToken, error) {
+	exportedSecret, err := ctx.Sender.Export(ExportLabel, ExportLength)
+	if err != nil {
+		return nil, fmt.Errorf("failed to export HPKE secret: %w", err)
+	}
 	requestEnc := make([]byte, len(ctx.RequestEnc))
 	copy(requestEnc, ctx.RequestEnc)
 	return &SessionRecoveryToken{
 		ExportedSecret: exportedSecret,
 		RequestEnc:     requestEnc,
-	}
+	}, nil
 }
 
 // DecryptResponseWithToken decrypts an HTTP response using only a


### PR DESCRIPTION
As of Go 1.26, Go has standard library support for hpke. This PR removes the Cloudflare CIRCL package in favor of the standard library: https://pkg.go.dev/crypto/hpke