### PR TITLE
fix: prevent memory exhaustion from oversized response chunks

### DIFF
--- a/identity/crypt.go
+++ b/identity/crypt.go
@@ -441,6 +441,10 @@ func (ctx *RequestContext) DecryptResponse(resp *http.Response) error {
 	return DecryptResponseWithToken(resp, token)
 }
 
+// maxResponseChunkBytes bounds a single framed response chunk so a malicious or
+// tampered length prefix cannot force an unbounded allocation on the client.
+const maxResponseChunkBytes = 64 << 20
+
 // DerivedStreamingDecryptReader decrypts response chunks using derived keys.
 type DerivedStreamingDecryptReader struct {
 	reader io.Reader
@@ -476,6 +480,9 @@ func (r *DerivedStreamingDecryptReader) Read(p []byte) (n int, err error) {
 	chunkLen := binary.BigEndian.Uint32(chunkLenBytes)
 	if chunkLen == 0 {
 		return r.Read(p) // Skip empty chunks
+	}
+	if chunkLen > maxResponseChunkBytes {
+		return 0, fmt.Errorf("encrypted response chunk exceeds maximum allowed size")
 	}
 
 	// Read encrypted chunk

--- a/identity/crypt_test.go
+++ b/identity/crypt_test.go
@@ -1018,3 +1018,16 @@ func TestDerivedStreamingDecryptReaderClose(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestDerivedStreamingDecryptReaderRejectsOversizedChunk(t *testing.T) {
+	// A 4-byte length prefix declaring a ~4 GiB chunk must be rejected before the
+	// reader allocates a buffer for the unauthenticated, attacker-controlled length.
+	framed := []byte{0xFF, 0xFF, 0xFF, 0xFF}
+	reader := &DerivedStreamingDecryptReader{
+		reader: bytes.NewReader(framed),
+	}
+
+	_, err := reader.Read(make([]byte, 16))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "maximum allowed size")
+}

--- a/js/src/identity.ts
+++ b/js/src/identity.ts
@@ -401,6 +401,14 @@ function createDecryptStream(
 
   return new ReadableStream({
     async pull(controller) {
+      // Erroring the output stream does not invoke the cancel() handler below,
+      // so the upstream body must be cancelled explicitly; otherwise a rejected
+      // (e.g. oversized) chunk leaves the underlying response downloading.
+      const fail = (error: Error) => {
+        controller.error(error);
+        reader.cancel(error).catch(() => {});
+      };
+
       while (true) {
         if (buffer.length >= 4) {
           const chunkLength =
@@ -412,9 +420,7 @@ function createDecryptStream(
           }
 
           if (chunkLength > MAX_RESPONSE_CHUNK_BYTES) {
-            controller.error(
-              new ProtocolError('response chunk exceeds maximum allowed size'),
-            );
+            fail(new ProtocolError('response chunk exceeds maximum allowed size'));
             return;
           }
 
@@ -427,7 +433,7 @@ function createDecryptStream(
               controller.enqueue(plaintext);
               return;
             } catch (error) {
-              controller.error(new DecryptionError(
+              fail(new DecryptionError(
                 `Decryption failed at chunk ${seq - 1}`,
                 { cause: error }
               ));

--- a/js/src/identity.ts
+++ b/js/src/identity.ts
@@ -389,6 +389,8 @@ export async function decryptResponseWithToken(
   });
 }
 
+const MAX_RESPONSE_CHUNK_BYTES = 64 * 1024 * 1024;
+
 function createDecryptStream(
   body: ReadableStream<Uint8Array>,
   km: ResponseKeyMaterial,
@@ -402,11 +404,18 @@ function createDecryptStream(
       while (true) {
         if (buffer.length >= 4) {
           const chunkLength =
-            (buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3];
+            ((buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3]) >>> 0;
 
           if (chunkLength === 0) {
             buffer = buffer.slice(4);
             continue;
+          }
+
+          if (chunkLength > MAX_RESPONSE_CHUNK_BYTES) {
+            controller.error(
+              new ProtocolError('response chunk exceeds maximum allowed size'),
+            );
+            return;
           }
 
           if (buffer.length >= 4 + chunkLength) {

--- a/js/src/test/session-recovery.test.ts
+++ b/js/src/test/session-recovery.test.ts
@@ -395,6 +395,26 @@ describe('Session Recovery Token', () => {
       );
     });
 
+    it('should reject a response chunk that exceeds the maximum size', async () => {
+      const token: SessionRecoveryToken = {
+        exportedSecret: new Uint8Array(32),
+        requestEnc: new Uint8Array(32),
+      };
+
+      // Valid 32-byte nonce so key derivation proceeds, but the length prefix
+      // declares a ~4 GiB chunk that must be rejected before buffering the
+      // (unauthenticated) body.
+      const nonce = bytesToHex(new Uint8Array(RESPONSE_NONCE_LENGTH));
+      const body = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x00]);
+      const response = new Response(body, {
+        status: 200,
+        headers: { [PROTOCOL.RESPONSE_NONCE_HEADER]: nonce },
+      });
+
+      const decrypted = await decryptResponseWithToken(response, token);
+      await assert.rejects(() => decrypted.text(), /maximum allowed size/);
+    });
+
     it('should fail decryption with a wrong token', async () => {
       const { identity, privateKey } = await generateTestKeys();
       const request = new Request('https://server.test/api', {

--- a/js/src/test/session-recovery.test.ts
+++ b/js/src/test/session-recovery.test.ts
@@ -415,6 +415,38 @@ describe('Session Recovery Token', () => {
       await assert.rejects(() => decrypted.text(), /maximum allowed size/);
     });
 
+    it('should cancel the upstream body when a chunk exceeds the maximum size', async () => {
+      const token: SessionRecoveryToken = {
+        exportedSecret: new Uint8Array(32),
+        requestEnc: new Uint8Array(32),
+      };
+
+      let upstreamCancelled = false;
+      const upstream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          // Oversized length prefix (~4 GiB); a real attacker keeps streaming.
+          controller.enqueue(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x00]));
+        },
+        cancel() {
+          upstreamCancelled = true;
+        },
+      });
+
+      const nonce = bytesToHex(new Uint8Array(RESPONSE_NONCE_LENGTH));
+      const response = new Response(upstream, {
+        status: 200,
+        headers: { [PROTOCOL.RESPONSE_NONCE_HEADER]: nonce },
+      });
+
+      const decrypted = await decryptResponseWithToken(response, token);
+      await assert.rejects(() => decrypted.text(), /maximum allowed size/);
+      assert.strictEqual(
+        upstreamCancelled,
+        true,
+        'upstream body should be cancelled on oversized chunk',
+      );
+    });
+
     it('should fail decryption with a wrong token', async () => {
       const { identity, privateKey } = await generateTestKeys();
       const request = new Request('https://server.test/api', {

--- a/python/src/ehbp/client.py
+++ b/python/src/ehbp/client.py
@@ -301,7 +301,7 @@ class Client:
     def _decrypt_stream(
         self, resp: httpx.Response, token: SessionRecoveryToken, key_material: Any
     ) -> Iterator[bytes]:
-        decryptor = FrameDecryptor(key_material)
+        decryptor = FrameDecryptor(key_material, self._max_response_bytes)
         try:
             for chunk in resp.iter_bytes():
                 yield from decryptor.push(chunk)

--- a/python/src/ehbp/derive.py
+++ b/python/src/ehbp/derive.py
@@ -151,10 +151,13 @@ class FrameDecryptor:
     number, matching the framing rules in SPEC Section 4.3.
     """
 
-    def __init__(self, km: ResponseKeyMaterial) -> None:
+    def __init__(
+        self, km: ResponseKeyMaterial, max_chunk_length: int = MAX_CHUNK_LENGTH
+    ) -> None:
         self._km = km
         self._buffer = bytearray()
         self._seq = 0
+        self._max_chunk_length = max_chunk_length
 
     def push(self, data: bytes) -> list[bytes]:
         self._buffer += data
@@ -167,6 +170,8 @@ class FrameDecryptor:
             if chunk_len == 0:
                 del self._buffer[:LENGTH_PREFIX_SIZE]
                 continue
+            if chunk_len > self._max_chunk_length:
+                raise ProtocolError("response chunk exceeds maximum allowed size")
             if len(self._buffer) < LENGTH_PREFIX_SIZE + chunk_len:
                 break
 

--- a/python/tests/test_derive.py
+++ b/python/tests/test_derive.py
@@ -71,3 +71,13 @@ def test_streaming_decryptor_handles_fragmented_frames():
             out += chunk
     decryptor.finish()
     assert bytes(out) == b"abcdefgh"
+
+
+def test_streaming_decryptor_rejects_oversized_chunk_length():
+    km = _key_material()
+    decryptor = FrameDecryptor(km, max_chunk_length=16)
+    # A length prefix declaring a 1 MiB chunk must be rejected before buffering
+    # the (unauthenticated) chunk body, even if no body bytes have arrived yet.
+    oversized_prefix = (1 << 20).to_bytes(4, "big")
+    with pytest.raises(ProtocolError):
+        decryptor.push(oversized_prefix)

--- a/swift/Sources/EHBP/Client.swift
+++ b/swift/Sources/EHBP/Client.swift
@@ -234,6 +234,10 @@ public final class EHBPClient: @unchecked Sendable {
                                 continue
                             }
 
+                            if chunkLength > EHBPConstants.maxResponseChunkBytes {
+                                throw EHBPError.invalidResponse("response chunk exceeds maximum allowed size")
+                            }
+
                             guard buffer.count >= 4 + chunkLength else {
                                 break
                             }

--- a/swift/Sources/EHBP/Protocol.swift
+++ b/swift/Sources/EHBP/Protocol.swift
@@ -55,4 +55,8 @@ public enum EHBPConstants {
 
     /// Label for deriving response nonce
     public static let responseNonceLabel = "nonce"
+
+    /// Maximum size of a single framed response chunk the client will buffer
+    /// (64 MiB). Bounds memory from an attacker-controlled length prefix.
+    public static let maxResponseChunkBytes = 64 * 1024 * 1024
 }

--- a/swift/Tests/EHBPTests/StreamingTests.swift
+++ b/swift/Tests/EHBPTests/StreamingTests.swift
@@ -348,4 +348,40 @@ final class StreamingTests: XCTestCase {
         let decrypted = try decryptChunk(keyMaterial: keyMaterial, seq: 0, ciphertext: ciphertext)
         XCTAssertEqual(decrypted, plaintext)
     }
+
+    /// Mirrors the requestStream cap in Client.swift: a length prefix larger than
+    /// the maximum chunk size must be rejected before buffering the chunk body.
+    func testStreamingRejectsOversizedChunkLength() throws {
+        // Length prefix declaring a ~4 GiB chunk (0xFFFFFFFF).
+        var buffer: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF]
+
+        func parseFramedChunks() throws {
+            while buffer.count >= 4 {
+                let chunkLength = Int(buffer[0]) << 24 |
+                                  Int(buffer[1]) << 16 |
+                                  Int(buffer[2]) << 8 |
+                                  Int(buffer[3])
+
+                if chunkLength == 0 {
+                    buffer.removeFirst(4)
+                    continue
+                }
+
+                if chunkLength > EHBPConstants.maxResponseChunkBytes {
+                    throw EHBPError.invalidResponse("response chunk exceeds maximum allowed size")
+                }
+
+                guard buffer.count >= 4 + chunkLength else {
+                    break
+                }
+                buffer.removeFirst(4 + chunkLength)
+            }
+        }
+
+        XCTAssertThrowsError(try parseFramedChunks()) { error in
+            guard case EHBPError.invalidResponse = error else {
+                return XCTFail("expected invalidResponse, got \(error)")
+            }
+        }
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent memory exhaustion by capping streamed response chunk size at 64 MiB and rejecting oversized chunks before allocation. Also cancel the response download on decryption errors to avoid wasted bandwidth.

- **Bug Fixes**
  - Enforced a 64 MiB max chunk size in Go (`DerivedStreamingDecryptReader`), JS (`createDecryptStream` with unsigned 32-bit length), Python (`FrameDecryptor` with `max_chunk_length` passed from the client), and Swift (`EHBPClient` using `EHBPConstants.maxResponseChunkBytes`).
  - JS now cancels the upstream body when a chunk exceeds the limit or decryption fails; added tests across languages to reject oversized prefixes before buffering, and a JS test to confirm cancellation.

<sup>Written for commit b1cdcf605bc756cb0de4b7c045920a3aa384322d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

