### PR TITLE
chore: add script to bump version across all clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+Notes for AI agents and contributors working in this repository.
+
+## Updating the version
+
+This project publishes clients in several languages, and a few of them declare
+their version in-tree. **Always bump the version with the helper script** so
+every place stays in lockstep instead of editing files by hand:
+
+```sh
+./scripts/bump-version.sh <new-version>    # e.g. ./scripts/bump-version.sh 0.2.1
+```
+
+The script updates every in-tree version and keeps the lockfiles in sync:
+
+| Client     | Files updated                                                          |
+| ---------- | --------------------------------------------------------------------- |
+| JavaScript | `js/package.json`, `js/package-lock.json`                             |
+| Python     | `python/pyproject.toml`, `python/src/ehbp/__init__.py` (`__version__`) |
+| Rust       | `rust/Cargo.toml`, `rust/Cargo.lock`                                   |
+
+The JavaScript lockfile is updated through `npm`; if `npm` is not installed the
+script bumps `package.json` and tells you to run `npm install --package-lock-only`
+to finish syncing the lockfile.
+
+**Go** and **Swift** have no version to edit — they are released purely by the
+git tag, so creating the `v<new-version>` tag is what ships them.
+
+### Release steps
+
+1. `./scripts/bump-version.sh <new-version>`
+2. Review `git diff` — only version lines should change.
+3. Commit: `chore: bump version to v<new-version>`
+4. Tag and push: `git tag v<new-version> && git push origin v<new-version>`
+
+Keep all client versions aligned with the git tag.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -19,8 +19,16 @@ fi
 
 VERSION="$1"
 
-# Reject anything that is not a basic SemVer so a malformed version is never written.
-if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
+# Reject anything that is not valid SemVer 2.0.0 (https://semver.org) so a
+# malformed version is never written. grep uses POSIX ERE, which lacks the
+# non-capturing groups of the canonical regex, so the grammar is spelled out:
+# numeric identifiers forbid leading zeros, and the optional pre-release and
+# build-metadata sections may appear together (e.g. 1.2.3-rc.1+build.5).
+num='(0|[1-9][0-9]*)'
+pre='(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)'
+build='[0-9A-Za-z-]+'
+semver="^${num}\.${num}\.${num}(-${pre}(\.${pre})*)?(\+${build}(\.${build})*)?\$"
+if ! printf '%s' "$VERSION" | grep -Eq "$semver"; then
   echo "error: '$VERSION' is not a valid semantic version (expected e.g. 0.2.1)" >&2
   exit 1
 fi

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -20,7 +20,7 @@ fi
 VERSION="$1"
 
 # Reject anything that is not valid SemVer 2.0.0 (https://semver.org) so a
-# malformed version is never written. grep uses POSIX ERE, which lacks the
+# malformed version is never written. Bash's =~ uses POSIX ERE, which lacks the
 # non-capturing groups of the canonical regex, so the grammar is spelled out:
 # numeric identifiers forbid leading zeros, and the optional pre-release and
 # build-metadata sections may appear together (e.g. 1.2.3-rc.1+build.5).
@@ -28,7 +28,11 @@ num='(0|[1-9][0-9]*)'
 pre='(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)'
 build='[0-9A-Za-z-]+'
 semver="^${num}\.${num}\.${num}(-${pre}(\.${pre})*)?(\+${build}(\.${build})*)?\$"
-if ! printf '%s' "$VERSION" | grep -Eq "$semver"; then
+# Match the whole value with =~; a line-oriented matcher like grep accepts a
+# multiline value as long as any one line matches, smuggling garbage past
+# validation. Reject embedded newlines outright too, since POSIX $ can also
+# match just before a trailing newline.
+if [[ "$VERSION" == *$'\n'* ]] || ! [[ "$VERSION" =~ $semver ]]; then
   echo "error: '$VERSION' is not a valid semantic version (expected e.g. 0.2.1)" >&2
   exit 1
 fi

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Bump the EHBP version across every client that declares it in-tree.
+#
+# Go and Swift are versioned solely by the git tag, so they have no version to
+# edit here; creating the matching `v<version>` tag is what releases them.
+#
+# Usage:
+#   scripts/bump-version.sh <new-version>
+# Example:
+#   scripts/bump-version.sh 0.2.1
+#
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $(basename "$0") <new-version>  (e.g. 0.2.1)" >&2
+  exit 1
+fi
+
+VERSION="$1"
+
+# Reject anything that is not a basic SemVer so a malformed version is never written.
+if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
+  echo "error: '$VERSION' is not a valid semantic version (expected e.g. 0.2.1)" >&2
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# In-place sed that works on both BSD/macOS and GNU/Linux (their `-i` flags differ).
+replace_in_file() {
+  # usage: replace_in_file <sed-expression> <file>
+  local expr="$1" file="$2" tmp
+  tmp="$(mktemp)"
+  sed -E "$expr" "$file" >"$tmp"
+  mv "$tmp" "$file"
+}
+
+echo "Bumping EHBP to v$VERSION"
+
+# --- JavaScript: npm owns both package.json and package-lock.json ---
+if command -v npm >/dev/null 2>&1; then
+  (cd "$ROOT/js" && npm version "$VERSION" \
+    --no-git-tag-version --allow-same-version --ignore-scripts >/dev/null)
+else
+  echo "  warning: npm not found; updating package.json only -- run" \
+    "'npm install --package-lock-only' in js/ to sync the lockfile" >&2
+  replace_in_file "s/(\"version\": \").*(\",)/\1$VERSION\2/" "$ROOT/js/package.json"
+fi
+echo "  updated js/package.json (+ package-lock.json)"
+
+# --- Python: pyproject.toml [project].version and the package __version__ ---
+replace_in_file "s/^version *=.*/version = \"$VERSION\"/" "$ROOT/python/pyproject.toml"
+replace_in_file "s/^__version__ *=.*/__version__ = \"$VERSION\"/" "$ROOT/python/src/ehbp/__init__.py"
+echo "  updated python/pyproject.toml + src/ehbp/__init__.py"
+
+# --- Rust: Cargo.toml [package].version and the local crate entry in Cargo.lock ---
+replace_in_file "s/^version *=.*/version = \"$VERSION\"/" "$ROOT/rust/Cargo.toml"
+tmp="$(mktemp)"
+awk -v ver="$VERSION" '
+  /^name = "tinfoil-ehbp"$/ {
+    print
+    if ((getline line) > 0) {
+      if (line ~ /^version = /) line = "version = \"" ver "\""
+      print line
+    }
+    next
+  }
+  { print }
+' "$ROOT/rust/Cargo.lock" >"$tmp"
+mv "$tmp" "$ROOT/rust/Cargo.lock"
+echo "  updated rust/Cargo.toml + Cargo.lock"
+
+echo
+echo "Versions now set:"
+grep -E '^[[:space:]]*"version"|^version|^__version__' \
+  "$ROOT/js/package.json" \
+  "$ROOT/python/pyproject.toml" \
+  "$ROOT/python/src/ehbp/__init__.py" \
+  "$ROOT/rust/Cargo.toml" || true
+
+echo
+echo "Go and Swift release via the git tag (v$VERSION) -- no files to change."
+echo "Next: review 'git diff', commit, then 'git tag v$VERSION'."


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a cross-client version bump script with strict SemVer 2.0 validation (rejects multiline input) and release docs. Go/Swift remain tag-only via the `v<version>` git tag.

- **New Features**
  - Script: `scripts/bump-version.sh <new-version>`
  - JS: runs `npm version` to update `js/package.json` and `package-lock.json`, or edits `package.json` if `npm` is missing
  - Python: updates `python/pyproject.toml` and `python/src/ehbp/__init__.py` `__version__`
  - Rust: updates `rust/Cargo.toml` and the crate entry in `rust/Cargo.lock`
  - Prints a summary and next steps; `AGENTS.md` documents the release flow and tagging steps

<sup>Written for commit 4a01122ff3d517c19e238670b50f8f642520251f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

