### PR TITLE
Extend EHBP client features 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -30,10 +30,32 @@ type problemDetails struct {
 
 var _ http.RoundTripper = (*Transport)(nil)
 
-func NewTransport(server string) (*Transport, error) {
+// Option configures a Transport.
+type Option func(*Transport)
+
+// WithHTTPClient sets the underlying HTTP client used to send encrypted
+// requests (and, for NewTransport, to fetch the server key configuration). It
+// lets callers compose EHBP with a TLS-pinned or otherwise customized
+// http.Client.
+func WithHTTPClient(c *http.Client) Option {
+	return func(t *Transport) {
+		t.httpClient = c
+	}
+}
+
+func applyOptions(t *Transport, opts []Option) {
+	for _, opt := range opts {
+		if opt != nil {
+			opt(t)
+		}
+	}
+}
+
+func NewTransport(server string, opts ...Option) (*Transport, error) {
 	t := &Transport{
 		httpClient: &http.Client{},
 	}
+	applyOptions(t, opts)
 
 	if err := t.syncServerPublicKey(server); err != nil {
 		return nil, fmt.Errorf("failed to sync server public key: %v", err)
@@ -44,16 +66,34 @@ func NewTransport(server string) (*Transport, error) {
 
 // NewTransportWithConfig creates a new Transport with a pre-fetched HPKE key configuration.
 // The hpkeConfig should be the raw bytes from /.well-known/hpke-keys (RFC 9458 format).
-func NewTransportWithConfig(server string, hpkeConfig []byte) (*Transport, error) {
+func NewTransportWithConfig(server string, hpkeConfig []byte, opts ...Option) (*Transport, error) {
 	serverIdentity, err := identity.UnmarshalPublicConfig(hpkeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal public key config: %v", err)
 	}
 
-	return &Transport{
+	t := &Transport{
 		serverIdentity: serverIdentity,
 		httpClient:     &http.Client{},
-	}, nil
+	}
+	applyOptions(t, opts)
+	return t, nil
+}
+
+// NewTransportWithIdentity creates a Transport from an already-trusted server
+// identity, for example one built from an attestation-verified HPKE public key
+// via identity.FromPublicKeyHex. No network request is made to fetch keys.
+func NewTransportWithIdentity(serverIdentity *identity.Identity, opts ...Option) (*Transport, error) {
+	if serverIdentity == nil {
+		return nil, fmt.Errorf("server identity is required")
+	}
+
+	t := &Transport{
+		serverIdentity: serverIdentity,
+		httpClient:     &http.Client{},
+	}
+	applyOptions(t, opts)
+	return t, nil
 }
 
 func (t *Transport) syncServerPublicKey(server string) error {

--- a/client/client.go
+++ b/client/client.go
@@ -36,10 +36,12 @@ type Option func(*Transport)
 // WithHTTPClient sets the underlying HTTP client used to send encrypted
 // requests (and, for NewTransport, to fetch the server key configuration). It
 // lets callers compose EHBP with a TLS-pinned or otherwise customized
-// http.Client.
+// http.Client. A nil client is ignored so the default remains in place.
 func WithHTTPClient(c *http.Client) Option {
 	return func(t *Transport) {
-		t.httpClient = c
+		if c != nil {
+			t.httpClient = c
+		}
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -111,6 +111,95 @@ func TestSecureClient(t *testing.T) {
 	})
 }
 
+func TestNewTransportWithIdentity(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+
+	middleware := serverIdentity.Middleware()
+	mux := http.NewServeMux()
+	mux.Handle("/secure", middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read request body", http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte("Hello, " + string(body)))
+	})))
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Build a public-only identity from the server's attested public key, with
+	// no network fetch of the key configuration.
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+
+	transport, err := NewTransportWithIdentity(pubIdentity)
+	assert.NoError(t, err)
+
+	httpClient := &http.Client{Transport: transport}
+	req, err := http.NewRequest("POST", server.URL+"/secure", bytes.NewBuffer([]byte("test")))
+	assert.NoError(t, err)
+
+	resp, err := httpClient.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello, test", string(body))
+}
+
+func TestNewTransportWithIdentityRequiresIdentity(t *testing.T) {
+	_, err := NewTransportWithIdentity(nil)
+	assert.Error(t, err)
+}
+
+type recordingRoundTripper struct {
+	inner http.RoundTripper
+	count int
+}
+
+func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.count++
+	return r.inner.RoundTrip(req)
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+
+	middleware := serverIdentity.Middleware()
+	mux := http.NewServeMux()
+	mux.Handle("/secure", middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_, _ = w.Write([]byte("Hello, " + string(body)))
+	})))
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+
+	rec := &recordingRoundTripper{inner: http.DefaultTransport}
+	transport, err := NewTransportWithIdentity(pubIdentity, WithHTTPClient(&http.Client{Transport: rec}))
+	assert.NoError(t, err)
+
+	httpClient := &http.Client{Transport: transport}
+	req, err := http.NewRequest("POST", server.URL+"/secure", bytes.NewBuffer([]byte("test")))
+	assert.NoError(t, err)
+
+	resp, err := httpClient.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello, test", string(body))
+	assert.GreaterOrEqual(t, rec.count, 1, "injected http client must be used to send encrypted requests")
+}
+
 func TestTransportReturnsErrorOnKeyConfigMismatch(t *testing.T) {
 	identityA, err := identity.NewIdentity()
 	assert.NoError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -200,6 +200,19 @@ func TestWithHTTPClient(t *testing.T) {
 	assert.GreaterOrEqual(t, rec.count, 1, "injected http client must be used to send encrypted requests")
 }
 
+func TestWithHTTPClientIgnoresNil(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+
+	// A nil client must not null out the default, which would panic on use.
+	transport, err := NewTransportWithIdentity(pubIdentity, WithHTTPClient(nil))
+	assert.NoError(t, err)
+	assert.NotNil(t, transport.httpClient)
+}
+
 func TestTransportReturnsErrorOnKeyConfigMismatch(t *testing.T) {
 	identityA, err := identity.NewIdentity()
 	assert.NoError(t, err)

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -64,6 +64,36 @@ func NewIdentity() (*Identity, error) {
 	}, nil
 }
 
+// FromPublicKeyBytes builds a public-key-only identity from a raw HPKE public
+// key using the default suite (DHKEM-X25519-HKDF-SHA256 / HKDF-SHA256 /
+// AES-256-GCM). The resulting identity can encrypt requests but never decrypt.
+func FromPublicKeyBytes(publicKey []byte) (*Identity, error) {
+	kem := hpke.DHKEM(ecdh.X25519())
+
+	pk, err := kem.NewPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid public key: %w", err)
+	}
+
+	return &Identity{
+		pk:   pk,
+		sk:   nil,
+		kem:  kem,
+		kdf:  hpke.HKDFSHA256(),
+		aead: hpke.AES256GCM(),
+	}, nil
+}
+
+// FromPublicKeyHex builds a public-key-only identity from a hex-encoded HPKE
+// public key. See FromPublicKeyBytes.
+func FromPublicKeyHex(publicKeyHex string) (*Identity, error) {
+	raw, err := hex.DecodeString(publicKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid public key hex: %w", err)
+	}
+	return FromPublicKeyBytes(raw)
+}
+
 // FromFile loads an identity from a file or creates a new one if it doesn't exist
 func FromFile(filename string) (*Identity, error) {
 	var i *Identity

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -219,6 +219,39 @@ func TestUnmarshalPublicConfigErrorCases(t *testing.T) {
 	}
 }
 
+func TestFromPublicKeyHex(t *testing.T) {
+	original, err := NewIdentity()
+	require.NoError(t, err)
+
+	pub, err := FromPublicKeyHex(original.MarshalPublicKeyHex())
+	require.NoError(t, err)
+
+	assert.Equal(t, original.pk.Bytes(), pub.pk.Bytes())
+	assert.Equal(t, uint16(0x0020), pub.kem.ID())
+	assert.Equal(t, uint16(0x0001), pub.kdf.ID())
+	assert.Equal(t, uint16(0x0002), pub.aead.ID())
+	assert.Nil(t, pub.sk) // public key only
+}
+
+func TestFromPublicKeyBytes(t *testing.T) {
+	original, err := NewIdentity()
+	require.NoError(t, err)
+
+	pub, err := FromPublicKeyBytes(original.MarshalPublicKey())
+	require.NoError(t, err)
+
+	assert.Equal(t, original.pk.Bytes(), pub.pk.Bytes())
+	assert.Nil(t, pub.sk)
+}
+
+func TestFromPublicKeyErrorCases(t *testing.T) {
+	_, err := FromPublicKeyHex("not-hex")
+	assert.Error(t, err)
+
+	_, err = FromPublicKeyBytes([]byte{0x01, 0x02, 0x03}) // wrong length for X25519
+	assert.Error(t, err)
+}
+
 func TestIdentityStoreStruct(t *testing.T) {
 	// Test that IdentityStore can be marshaled/unmarshaled
 	identity, err := NewIdentity()

--- a/python/src/ehbp/__init__.py
+++ b/python/src/ehbp/__init__.py
@@ -21,6 +21,7 @@ from .errors import (
 )
 from .identity import EncryptedRequest, ServerIdentity
 from .session import SessionRecoveryToken
+from .transport import AsyncEHBPTransport, EHBPTransport
 
 __version__ = "0.2.1"
 
@@ -28,6 +29,8 @@ __all__ = [
     "Client",
     "Response",
     "StreamingResponse",
+    "EHBPTransport",
+    "AsyncEHBPTransport",
     "ServerIdentity",
     "EncryptedRequest",
     "SessionRecoveryToken",

--- a/python/src/ehbp/_http.py
+++ b/python/src/ehbp/_http.py
@@ -1,0 +1,71 @@
+"""Shared wire-level helpers for the high-level client and the httpx transports.
+
+These implement concerns that are identical whether a request is driven through
+the convenience :class:`~ehbp.client.Client` or an httpx transport: building a
+chunked single-frame request body, recognising the key-configuration-mismatch
+problem response, and parsing the response nonce header.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+
+import httpx
+
+from .errors import KeyConfigMismatchError, ProtocolError
+from .protocol import (
+    KEY_CONFIG_PROBLEM_TYPE,
+    PROBLEM_JSON_MEDIA_TYPE,
+    RESPONSE_NONCE_HEADER,
+    RESPONSE_NONCE_LENGTH,
+)
+
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024 * 1024
+
+KEY_CONFIG_MISMATCH_STATUS = 422
+
+
+def single_chunk_body(body: bytes) -> Iterator[bytes]:
+    # Yielding from an iterator makes httpx use chunked transfer-encoding and
+    # omit Content-Length, as required for encrypted bodies (SPEC Section 4.1).
+    yield body
+
+
+def media_type(headers: httpx.Headers) -> str:
+    raw = headers.get("content-type", "")
+    return raw.split(";", 1)[0].strip().lower()
+
+
+def raise_for_key_config_mismatch(status: int, headers: httpx.Headers, body: bytes) -> None:
+    if status != KEY_CONFIG_MISMATCH_STATUS:
+        return
+    if media_type(headers) != PROBLEM_JSON_MEDIA_TYPE:
+        return
+    try:
+        problem = json.loads(body)
+    except (ValueError, TypeError):
+        return
+    if isinstance(problem, dict) and problem.get("type") == KEY_CONFIG_PROBLEM_TYPE:
+        title = problem.get("title")
+        if not isinstance(title, str):
+            title = "key configuration mismatch"
+        raise KeyConfigMismatchError(title)
+
+
+def response_nonce(headers: httpx.Headers) -> bytes:
+    values = headers.get_list(RESPONSE_NONCE_HEADER)
+    if not values:
+        raise ProtocolError(f"missing {RESPONSE_NONCE_HEADER} header")
+    if len(values) > 1:
+        raise ProtocolError(f"multiple {RESPONSE_NONCE_HEADER} headers")
+    try:
+        nonce = bytes.fromhex(values[0].strip())
+    except ValueError as err:
+        raise ProtocolError(f"invalid response nonce header: {err}") from err
+    if len(nonce) != RESPONSE_NONCE_LENGTH:
+        raise ProtocolError(
+            f"invalid response nonce length: expected {RESPONSE_NONCE_LENGTH}, got {len(nonce)}"
+        )
+    return nonce

--- a/python/src/ehbp/client.py
+++ b/python/src/ehbp/client.py
@@ -18,24 +18,30 @@ from typing import Any, Optional, Union
 
 import httpx
 
+from ._http import (
+    DEFAULT_MAX_RESPONSE_BYTES,
+    DEFAULT_TIMEOUT,
+)
+from ._http import (
+    raise_for_key_config_mismatch as _raise_for_key_config_mismatch,
+)
+from ._http import (
+    response_nonce as _response_nonce,
+)
+from ._http import (
+    single_chunk_body as _single_chunk_body,
+)
 from .derive import FrameDecryptor, derive_response_keys
-from .errors import InvalidInputError, KeyConfigMismatchError, ProtocolError
+from .errors import InvalidInputError, ProtocolError
 from .identity import ServerIdentity
 from .protocol import (
     ENCAPSULATED_KEY_HEADER,
-    KEY_CONFIG_PROBLEM_TYPE,
     KEYS_MEDIA_TYPE,
     KEYS_PATH,
-    PROBLEM_JSON_MEDIA_TYPE,
     RESPONSE_NONCE_HEADER,
-    RESPONSE_NONCE_LENGTH,
 )
 from .session import SessionRecoveryToken
 
-DEFAULT_TIMEOUT = 30.0
-DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024 * 1024
-
-_KEY_CONFIG_MISMATCH_STATUS = 422
 _RESERVED_REQUEST_HEADERS = frozenset(
     {
         "content-length",
@@ -375,12 +381,6 @@ def _as_bytes(body: Body) -> bytes:
     raise InvalidInputError("body must be bytes, str, or None")
 
 
-def _single_chunk_body(body: bytes) -> Iterator[bytes]:
-    # Yielding from an iterator makes httpx use chunked transfer-encoding and
-    # omit Content-Length, as required for encrypted bodies (SPEC Section 4.1).
-    yield body
-
-
 def _normalize_base_url(raw: Union[str, httpx.URL]) -> httpx.URL:
     url = httpx.URL(raw)
     if not url.host:
@@ -402,43 +402,3 @@ def _origin(url: httpx.URL) -> tuple[str, Optional[str], int]:
 
 def _same_origin(left: httpx.URL, right: httpx.URL) -> bool:
     return _origin(left) == _origin(right)
-
-
-def _media_type(headers: httpx.Headers) -> str:
-    raw = headers.get("content-type", "")
-    return raw.split(";", 1)[0].strip().lower()
-
-
-def _raise_for_key_config_mismatch(
-    status: int, headers: httpx.Headers, body: bytes
-) -> None:
-    if status != _KEY_CONFIG_MISMATCH_STATUS:
-        return
-    if _media_type(headers) != PROBLEM_JSON_MEDIA_TYPE:
-        return
-    try:
-        problem = json.loads(body)
-    except (ValueError, TypeError):
-        return
-    if isinstance(problem, dict) and problem.get("type") == KEY_CONFIG_PROBLEM_TYPE:
-        title = problem.get("title")
-        if not isinstance(title, str):
-            title = "key configuration mismatch"
-        raise KeyConfigMismatchError(title)
-
-
-def _response_nonce(headers: httpx.Headers) -> bytes:
-    values = headers.get_list(RESPONSE_NONCE_HEADER)
-    if not values:
-        raise ProtocolError(f"missing {RESPONSE_NONCE_HEADER} header")
-    if len(values) > 1:
-        raise ProtocolError(f"multiple {RESPONSE_NONCE_HEADER} headers")
-    try:
-        nonce = bytes.fromhex(values[0].strip())
-    except ValueError as err:
-        raise ProtocolError(f"invalid response nonce header: {err}") from err
-    if len(nonce) != RESPONSE_NONCE_LENGTH:
-        raise ProtocolError(
-            f"invalid response nonce length: expected {RESPONSE_NONCE_LENGTH}, got {len(nonce)}"
-        )
-    return nonce

--- a/python/src/ehbp/transport.py
+++ b/python/src/ehbp/transport.py
@@ -1,0 +1,230 @@
+"""Drop-in httpx transports that encrypt request bodies and decrypt responses.
+
+These let any httpx-based client (for example the OpenAI SDK) speak EHBP by
+wrapping an existing inner transport::
+
+    identity = ServerIdentity.from_public_key_hex(attested_hpke_key_hex)
+    transport = EHBPTransport(identity, inner=tls_pinned_transport)
+    client = httpx.Client(transport=transport)
+
+Request bodies are sealed to the server's HPKE public key; bodyless requests
+pass through unchanged. Responses are decrypted lazily so server-sent event
+streams work without buffering.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Optional, cast
+
+import httpx
+
+from ._http import (
+    DEFAULT_MAX_RESPONSE_BYTES,
+    raise_for_key_config_mismatch,
+    response_nonce,
+    single_chunk_body,
+)
+from .derive import FrameDecryptor, derive_response_keys
+from .errors import ProtocolError
+from .identity import ServerIdentity
+from .protocol import ENCAPSULATED_KEY_HEADER, RESPONSE_NONCE_HEADER
+from .session import SessionRecoveryToken
+
+_FRAMING_HEADERS = ("content-length", "transfer-encoding")
+
+
+async def _single_chunk_body_async(body: bytes) -> AsyncIterator[bytes]:
+    yield body
+
+
+def _encrypted_headers(request: httpx.Request, encapsulated_key: bytes) -> httpx.Headers:
+    headers = httpx.Headers(request.headers)
+    for name in _FRAMING_HEADERS:
+        if name in headers:
+            del headers[name]
+    headers[ENCAPSULATED_KEY_HEADER] = encapsulated_key.hex()
+    return headers
+
+
+def _decrypted_headers(response: httpx.Response) -> httpx.Headers:
+    headers = httpx.Headers(response.headers)
+    # The decrypted body length differs from the encrypted Content-Length, so
+    # drop it and let the end of the stream delimit the body.
+    if "content-length" in headers:
+        del headers["content-length"]
+    return headers
+
+
+def _make_decryptor(
+    token: SessionRecoveryToken, nonce: bytes, max_bytes: int
+) -> FrameDecryptor:
+    key_material = derive_response_keys(token.exported_secret, token.request_enc, nonce)
+    return FrameDecryptor(key_material, max_bytes)
+
+
+class _DecryptingByteStream(httpx.SyncByteStream):
+    def __init__(self, response: httpx.Response, decryptor: FrameDecryptor) -> None:
+        self._response = response
+        self._decryptor = decryptor
+
+    def __iter__(self) -> Iterator[bytes]:
+        try:
+            for chunk in cast(httpx.SyncByteStream, self._response.stream):
+                yield from self._decryptor.push(chunk)
+            self._decryptor.finish()
+        finally:
+            self._response.close()
+
+    def close(self) -> None:
+        self._response.close()
+
+
+class _AsyncDecryptingByteStream(httpx.AsyncByteStream):
+    def __init__(self, response: httpx.Response, decryptor: FrameDecryptor) -> None:
+        self._response = response
+        self._decryptor = decryptor
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        try:
+            async for chunk in cast(httpx.AsyncByteStream, self._response.stream):
+                for plaintext in self._decryptor.push(chunk):
+                    yield plaintext
+            self._decryptor.finish()
+        finally:
+            await self._response.aclose()
+
+    async def aclose(self) -> None:
+        await self._response.aclose()
+
+
+class EHBPTransport(httpx.BaseTransport):
+    """A synchronous httpx transport that speaks EHBP over an inner transport."""
+
+    def __init__(
+        self,
+        identity: ServerIdentity,
+        *,
+        inner: Optional[httpx.BaseTransport] = None,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+    ) -> None:
+        self._identity = identity
+        self._inner = inner if inner is not None else httpx.HTTPTransport()
+        self._max_response_bytes = max_response_bytes
+
+    @classmethod
+    def from_public_key_hex(
+        cls,
+        public_key_hex: str,
+        *,
+        inner: Optional[httpx.BaseTransport] = None,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+    ) -> EHBPTransport:
+        return cls(
+            ServerIdentity.from_public_key_hex(public_key_hex),
+            inner=inner,
+            max_response_bytes=max_response_bytes,
+        )
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        plaintext = request.read()
+        encrypted = self._identity.encrypt_request_body(plaintext)
+        if encrypted is None:
+            return self._inner.handle_request(request)
+
+        enc_request = httpx.Request(
+            method=request.method,
+            url=request.url,
+            headers=_encrypted_headers(request, encrypted.encapsulated_key),
+            content=single_chunk_body(encrypted.body),
+        )
+        response = self._inner.handle_request(enc_request)
+        return self._decrypt_response(response, encrypted.token)
+
+    def _decrypt_response(
+        self, response: httpx.Response, token: SessionRecoveryToken
+    ) -> httpx.Response:
+        if RESPONSE_NONCE_HEADER not in response.headers:
+            body = b"".join(cast(httpx.SyncByteStream, response.stream))
+            response.close()
+            raise_for_key_config_mismatch(response.status_code, response.headers, body)
+            raise ProtocolError(f"missing {RESPONSE_NONCE_HEADER} header")
+
+        nonce = response_nonce(response.headers)
+        decryptor = _make_decryptor(token, nonce, self._max_response_bytes)
+        return httpx.Response(
+            status_code=response.status_code,
+            headers=_decrypted_headers(response),
+            stream=_DecryptingByteStream(response, decryptor),
+            extensions=response.extensions,
+        )
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+class AsyncEHBPTransport(httpx.AsyncBaseTransport):
+    """An asynchronous httpx transport that speaks EHBP over an inner transport."""
+
+    def __init__(
+        self,
+        identity: ServerIdentity,
+        *,
+        inner: Optional[httpx.AsyncBaseTransport] = None,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+    ) -> None:
+        self._identity = identity
+        self._inner = inner if inner is not None else httpx.AsyncHTTPTransport()
+        self._max_response_bytes = max_response_bytes
+
+    @classmethod
+    def from_public_key_hex(
+        cls,
+        public_key_hex: str,
+        *,
+        inner: Optional[httpx.AsyncBaseTransport] = None,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+    ) -> AsyncEHBPTransport:
+        return cls(
+            ServerIdentity.from_public_key_hex(public_key_hex),
+            inner=inner,
+            max_response_bytes=max_response_bytes,
+        )
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        plaintext = await request.aread()
+        encrypted = self._identity.encrypt_request_body(plaintext)
+        if encrypted is None:
+            return await self._inner.handle_async_request(request)
+
+        enc_request = httpx.Request(
+            method=request.method,
+            url=request.url,
+            headers=_encrypted_headers(request, encrypted.encapsulated_key),
+            content=_single_chunk_body_async(encrypted.body),
+        )
+        response = await self._inner.handle_async_request(enc_request)
+        return await self._decrypt_response(response, encrypted.token)
+
+    async def _decrypt_response(
+        self, response: httpx.Response, token: SessionRecoveryToken
+    ) -> httpx.Response:
+        if RESPONSE_NONCE_HEADER not in response.headers:
+            chunks = [chunk async for chunk in cast(httpx.AsyncByteStream, response.stream)]
+            await response.aclose()
+            raise_for_key_config_mismatch(
+                response.status_code, response.headers, b"".join(chunks)
+            )
+            raise ProtocolError(f"missing {RESPONSE_NONCE_HEADER} header")
+
+        nonce = response_nonce(response.headers)
+        decryptor = _make_decryptor(token, nonce, self._max_response_bytes)
+        return httpx.Response(
+            status_code=response.status_code,
+            headers=_decrypted_headers(response),
+            stream=_AsyncDecryptingByteStream(response, decryptor),
+            extensions=response.extensions,
+        )
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()

--- a/python/src/ehbp/transport.py
+++ b/python/src/ehbp/transport.py
@@ -38,6 +38,28 @@ async def _single_chunk_body_async(body: bytes) -> AsyncIterator[bytes]:
     yield body
 
 
+def _read_capped(stream: httpx.SyncByteStream, max_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in stream:
+        total += len(chunk)
+        if total > max_bytes:
+            raise ProtocolError("response body exceeds maximum allowed size")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def _aread_capped(stream: httpx.AsyncByteStream, max_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in stream:
+        total += len(chunk)
+        if total > max_bytes:
+            raise ProtocolError("response body exceeds maximum allowed size")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def _encrypted_headers(request: httpx.Request, encapsulated_key: bytes) -> httpx.Headers:
     headers = httpx.Headers(request.headers)
     for name in _FRAMING_HEADERS:
@@ -137,6 +159,7 @@ class EHBPTransport(httpx.BaseTransport):
             url=request.url,
             headers=_encrypted_headers(request, encrypted.encapsulated_key),
             content=single_chunk_body(encrypted.body),
+            extensions=request.extensions,
         )
         response = self._inner.handle_request(enc_request)
         return self._decrypt_response(response, encrypted.token)
@@ -145,8 +168,12 @@ class EHBPTransport(httpx.BaseTransport):
         self, response: httpx.Response, token: SessionRecoveryToken
     ) -> httpx.Response:
         if RESPONSE_NONCE_HEADER not in response.headers:
-            body = b"".join(cast(httpx.SyncByteStream, response.stream))
-            response.close()
+            try:
+                body = _read_capped(
+                    cast(httpx.SyncByteStream, response.stream), self._max_response_bytes
+                )
+            finally:
+                response.close()
             raise_for_key_config_mismatch(response.status_code, response.headers, body)
             raise ProtocolError(f"missing {RESPONSE_NONCE_HEADER} header")
 
@@ -202,6 +229,7 @@ class AsyncEHBPTransport(httpx.AsyncBaseTransport):
             url=request.url,
             headers=_encrypted_headers(request, encrypted.encapsulated_key),
             content=_single_chunk_body_async(encrypted.body),
+            extensions=request.extensions,
         )
         response = await self._inner.handle_async_request(enc_request)
         return await self._decrypt_response(response, encrypted.token)
@@ -210,11 +238,13 @@ class AsyncEHBPTransport(httpx.AsyncBaseTransport):
         self, response: httpx.Response, token: SessionRecoveryToken
     ) -> httpx.Response:
         if RESPONSE_NONCE_HEADER not in response.headers:
-            chunks = [chunk async for chunk in cast(httpx.AsyncByteStream, response.stream)]
-            await response.aclose()
-            raise_for_key_config_mismatch(
-                response.status_code, response.headers, b"".join(chunks)
-            )
+            try:
+                body = await _aread_capped(
+                    cast(httpx.AsyncByteStream, response.stream), self._max_response_bytes
+                )
+            finally:
+                await response.aclose()
+            raise_for_key_config_mismatch(response.status_code, response.headers, body)
             raise ProtocolError(f"missing {RESPONSE_NONCE_HEADER} header")
 
         nonce = response_nonce(response.headers)

--- a/python/tests/test_transport.py
+++ b/python/tests/test_transport.py
@@ -90,6 +90,20 @@ def test_oversized_response_chunk_is_rejected(server: MockServer):
         client.post(URL, content=b"this response will exceed the tiny cap")
 
 
+def test_missing_nonce_response_body_is_capped(make_server):
+    server = make_server(mode="strip_nonce")
+    client = _sync_client(server, max_response_bytes=4)
+    with client, pytest.raises(ProtocolError) as excinfo:
+        client.post(URL, content=b"payload")
+    assert "exceeds maximum allowed size" in str(excinfo.value)
+
+
+def test_encrypted_request_preserves_extensions(server: MockServer):
+    with _sync_client(server) as client:
+        client.post(URL, content=b"payload")
+    assert "timeout" in server.last_request.extensions
+
+
 def test_async_encrypted_round_trip(server: MockServer):
     async def run() -> httpx.Response:
         async with _async_client(server) as client:
@@ -135,3 +149,24 @@ def test_async_key_config_mismatch_raises_dedicated_error(make_server):
 
     with pytest.raises(KeyConfigMismatchError):
         asyncio.run(run())
+
+
+def test_async_missing_nonce_response_body_is_capped(make_server):
+    server = make_server(mode="strip_nonce")
+
+    async def run() -> None:
+        async with _async_client(server, max_response_bytes=4) as client:
+            await client.post(URL, content=b"payload")
+
+    with pytest.raises(ProtocolError) as excinfo:
+        asyncio.run(run())
+    assert "exceeds maximum allowed size" in str(excinfo.value)
+
+
+def test_async_encrypted_request_preserves_extensions(server: MockServer):
+    async def run() -> None:
+        async with _async_client(server) as client:
+            await client.post(URL, content=b"payload")
+
+    asyncio.run(run())
+    assert "timeout" in server.last_request.extensions

--- a/python/tests/test_transport.py
+++ b/python/tests/test_transport.py
@@ -1,0 +1,137 @@
+"""Tests for the httpx EHBP transports against the in-process mock server."""
+
+import asyncio
+
+import httpx
+import pytest
+
+from conftest import MockServer
+from ehbp import AsyncEHBPTransport, EHBPTransport
+from ehbp.errors import KeyConfigMismatchError, ProtocolError
+from ehbp.protocol import ENCAPSULATED_KEY_HEADER
+
+URL = "https://server.example/v1/echo"
+
+
+def _sync_client(server: MockServer, **kwargs) -> httpx.Client:
+    transport = EHBPTransport.from_public_key_hex(
+        server.public_key_bytes.hex(),
+        inner=httpx.MockTransport(server.handler),
+        **kwargs,
+    )
+    return httpx.Client(transport=transport)
+
+
+def _async_client(server: MockServer, **kwargs) -> httpx.AsyncClient:
+    transport = AsyncEHBPTransport.from_public_key_hex(
+        server.public_key_bytes.hex(),
+        inner=httpx.MockTransport(server.handler),
+        **kwargs,
+    )
+    return httpx.AsyncClient(transport=transport)
+
+
+def test_encrypted_round_trip(server: MockServer):
+    with _sync_client(server) as client:
+        response = client.post(URL, content=b"hello world")
+    assert response.status_code == 200
+    assert response.content == b"echo:hello world"
+
+
+def test_multi_chunk_response_round_trip(make_server):
+    server = make_server(chunk_size=3)
+    with _sync_client(server) as client:
+        response = client.post(URL, content=b"abcdefghij")
+    assert response.content == b"echo:abcdefghij"
+
+
+def test_streaming_response_decrypts_lazily(make_server):
+    server = make_server(chunk_size=4)
+    collected = bytearray()
+    with _sync_client(server) as client, client.stream(
+        "POST", URL, content=b"streamed payload"
+    ) as response:
+        assert response.status_code == 200
+        for chunk in response.iter_bytes():
+            collected += chunk
+    assert bytes(collected) == b"echo:streamed payload"
+
+
+def test_encrypted_request_uses_chunked_body_without_content_length(server: MockServer):
+    with _sync_client(server) as client:
+        client.post(URL, content=b"payload")
+    headers = server.last_request.headers
+    assert ENCAPSULATED_KEY_HEADER in headers
+    assert "content-length" not in headers
+    assert headers.get("transfer-encoding") == "chunked"
+
+
+def test_bodyless_request_passes_through(server: MockServer):
+    with _sync_client(server) as client:
+        response = client.get("https://server.example/health")
+    assert response.content == b"plaintext ok"
+    assert ENCAPSULATED_KEY_HEADER not in server.last_request.headers
+
+
+def test_key_config_mismatch_raises_dedicated_error(make_server):
+    server = make_server(mode="key_config_mismatch")
+    with _sync_client(server) as client, pytest.raises(KeyConfigMismatchError):
+        client.post(URL, content=b"payload")
+
+
+def test_missing_response_nonce_fails_closed(make_server):
+    server = make_server(mode="strip_nonce")
+    with _sync_client(server) as client, pytest.raises(ProtocolError):
+        client.post(URL, content=b"payload")
+
+
+def test_oversized_response_chunk_is_rejected(server: MockServer):
+    with _sync_client(server, max_response_bytes=4) as client, pytest.raises(ProtocolError):
+        client.post(URL, content=b"this response will exceed the tiny cap")
+
+
+def test_async_encrypted_round_trip(server: MockServer):
+    async def run() -> httpx.Response:
+        async with _async_client(server) as client:
+            return await client.post(URL, content=b"hello world")
+
+    response = asyncio.run(run())
+    assert response.status_code == 200
+    assert response.content == b"echo:hello world"
+
+
+def test_async_streaming_response_decrypts_lazily(make_server):
+    server = make_server(chunk_size=4)
+
+    async def run() -> bytes:
+        collected = bytearray()
+        async with _async_client(server) as client, client.stream(
+            "POST", URL, content=b"streamed payload"
+        ) as response:
+            assert response.status_code == 200
+            async for chunk in response.aiter_bytes():
+                collected += chunk
+        return bytes(collected)
+
+    assert asyncio.run(run()) == b"echo:streamed payload"
+
+
+def test_async_bodyless_request_passes_through(server: MockServer):
+    async def run() -> httpx.Response:
+        async with _async_client(server) as client:
+            return await client.get("https://server.example/health")
+
+    response = asyncio.run(run())
+    assert response.content == b"plaintext ok"
+    assert ENCAPSULATED_KEY_HEADER not in server.last_request.headers
+
+
+def test_async_key_config_mismatch_raises_dedicated_error(make_server):
+    server = make_server(mode="key_config_mismatch")
+
+    async def run() -> None:
+        async with _async_client(server) as client:
+            await client.post(URL, content=b"payload")
+
+    with pytest.raises(KeyConfigMismatchError):
+        asyncio.run(run())


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds trusted-key transport construction in Go and drop-in encrypted `httpx` transports in Python, so EHBP can slot into existing SDKs and custom HTTP clients. Also introduces public-key identity helpers and shared wire helpers, plus safety tweaks for client injection and response buffering.

- New Features
  - Go: Build `Transport` from a trusted server identity with `NewTransportWithIdentity`; inject a custom HTTP client via `WithHTTPClient` (also supported by `NewTransport` and `NewTransportWithConfig`); nil clients are ignored.
  - Go: Create public-only identities from HPKE keys using `identity.FromPublicKeyBytes` and `identity.FromPublicKeyHex`.
  - Python: Add `EHBPTransport` and `AsyncEHBPTransport` for `httpx` that encrypt request bodies, decrypt responses lazily for streaming, and pass bodyless requests through; preserves request extensions like timeouts and caps response buffering; includes `from_public_key_hex` and `max_response_bytes`.

- Refactors
  - Python: Move shared request/response helpers (chunked body, key-config mismatch handling, nonce parsing) to `ehbp._http` and update the high-level client to use them; export `EHBPTransport` and `AsyncEHBPTransport` from `ehbp.__init__`.

<sup>Written for commit d67e507b8c00ee726cf2fe42e481c87195019bdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

