### PR TITLE
chore: bump version to v0.2.2

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ehbp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ehbp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@panva/hpke-noble": "^1.0.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ehbp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "JavaScript client for Encrypted HTTP Body Protocol (EHBP)",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tinfoil-ehbp"
-version = "0.2.1"
+version = "0.2.2"
 description = "Python client for the encrypted HTTP body protocol"
 license = "MIT"
 requires-python = ">=3.9"

--- a/python/src/ehbp/__init__.py
+++ b/python/src/ehbp/__init__.py
@@ -23,7 +23,7 @@ from .identity import EncryptedRequest, ServerIdentity
 from .session import SessionRecoveryToken
 from .transport import AsyncEHBPTransport, EHBPTransport
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     "Client",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "tinfoil-ehbp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes-gcm",
  "async-stream",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinfoil-ehbp"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.87"
 description = "Rust client for the encrypted HTTP body protocol"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump version to v0.2.2 across the JS `ehbp`, Python `tinfoil-ehbp`, and Rust `tinfoil-ehbp` packages for a synchronized patch release. No functional changes—only version updates to prepare publishing across ecosystems.

<sup>Written for commit c0175a4794b99607a6ac90433cd946c21ef15180. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

