### PR TITLE
fix: allow encrypted transport to run behind a reverse proxy

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -187,6 +187,15 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Create a copy of the request to avoid modifying the original
 	newReq := req.Clone(req.Context())
 
+	// A RoundTripper may be handed a request derived from an inbound server
+	// request (for example when used behind httputil.ReverseProxy), which
+	// carries RequestURI. http.Client.Do rejects any client request with
+	// RequestURI set, and the outbound request-target is taken from URL, so
+	// clear it. RequestURI is outside EHBP's protection (bodies only, empty
+	// AAD) and is not read during encryption, so clearing it changes no
+	// authenticated data.
+	newReq.RequestURI = ""
+
 	// Encrypt request to server's public key and get context for response decryption
 	// For bodyless requests, reqCtx will be nil - response passes through unencrypted
 	reqCtx, err := t.serverIdentity.EncryptRequestWithContext(newReq)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -155,6 +155,49 @@ func TestNewTransportWithIdentityRequiresIdentity(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestTransportClearsRequestURI ensures the transport can carry a request that
+// originated as an inbound server request, which is how httputil.ReverseProxy
+// drives a RoundTripper. Such requests have RequestURI populated, and
+// http.Client.Do rejects that; the transport must clear it before sending.
+func TestTransportClearsRequestURI(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+
+	middleware := serverIdentity.Middleware()
+	mux := http.NewServeMux()
+	mux.Handle("/secure", middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_, _ = w.Write([]byte("Hello, " + string(body)))
+	})))
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+
+	transport, err := NewTransportWithIdentity(pubIdentity)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest("POST", server.URL+"/secure", bytes.NewBuffer([]byte("test")))
+	assert.NoError(t, err)
+	// Populated by the http server on inbound requests and preserved by
+	// req.Clone; forwarding it unchanged would make http.Client.Do fail.
+	req.RequestURI = "/secure"
+
+	// Call RoundTrip directly, mirroring how a reverse proxy invokes the
+	// transport (http.Client.Do would reject RequestURI before the transport).
+	resp, err := transport.RoundTrip(req)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello, test", string(body))
+}
+
 type recordingRoundTripper struct {
 	inner http.RoundTripper
 	count int


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow the encrypted transport to work behind a reverse proxy by clearing `RequestURI` on outbound requests, preventing `http.Client.Do` from rejecting them. This keeps the request target sourced from `URL` and does not affect encrypted/authenticated data.

- **Bug Fixes**
  - Clear `RequestURI` in `Transport.RoundTrip` to support `httputil.ReverseProxy`-derived requests.
  - Add `TestTransportClearsRequestURI` to cover the reverse proxy flow and verify request/response handling.

<sup>Written for commit 5b61ed891e268ddd59dcb800cc8c30e68a69fed4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

