### PR TITLE
chore: bump version to v0.2.4

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ehbp",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ehbp",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@panva/hpke-noble": "^1.0.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ehbp",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "JavaScript client for Encrypted HTTP Body Protocol (EHBP)",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tinfoil-ehbp"
-version = "0.2.3"
+version = "0.2.4"
 description = "Python client for the encrypted HTTP body protocol"
 license = "MIT"
 requires-python = ">=3.9"

--- a/python/src/ehbp/__init__.py
+++ b/python/src/ehbp/__init__.py
@@ -23,7 +23,7 @@ from .identity import EncryptedRequest, ServerIdentity
 from .session import SessionRecoveryToken
 from .transport import AsyncEHBPTransport, EHBPTransport
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 __all__ = [
     "Client",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "tinfoil-ehbp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aes-gcm",
  "async-stream",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinfoil-ehbp"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.87"
 description = "Rust client for the encrypted HTTP body protocol"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped versions to v0.2.4 across JS `ehbp` and Python/Rust `tinfoil-ehbp` packages to prepare the release and keep clients in sync. No functional changes; only version metadata updates.

<sup>Written for commit 562b1871ed71e8ddedffda37ed8860d0faa328f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

