### PR TITLE
Strip Content-Length header from decrypted responses

### DIFF
--- a/identity/session_recovery.go
+++ b/identity/session_recovery.go
@@ -106,6 +106,7 @@ func DecryptResponseWithToken(resp *http.Response, token *SessionRecoveryToken) 
 		eof:    false,
 	}
 	resp.ContentLength = -1
+	resp.Header.Del("Content-Length")
 
 	return nil
 }

--- a/js/src/identity.ts
+++ b/js/src/identity.ts
@@ -382,10 +382,13 @@ export async function decryptResponseWithToken(
   const km = await deriveResponseKeys(token.exportedSecret, token.requestEnc, responseNonce);
   const decryptedStream = createDecryptStream(response.body, km);
 
+  const headers = new Headers(response.headers);
+  headers.delete('content-length');
+
   return new Response(decryptedStream, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
+    headers,
   });
 }
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -223,6 +223,9 @@ impl Client {
         };
         self.clear_session_recovery_token_if_current(&token);
 
+        let mut headers = headers;
+        headers.remove(CONTENT_LENGTH);
+
         Ok(Response {
             status,
             headers,
@@ -293,6 +296,9 @@ impl Client {
                     return Err(err);
                 }
             };
+
+        let mut headers = headers;
+        headers.remove(CONTENT_LENGTH);
 
         Ok(StreamingResponse {
             status,

--- a/swift/Sources/EHBP/Client.swift
+++ b/swift/Sources/EHBP/Client.swift
@@ -122,7 +122,9 @@ public final class EHBPClient: @unchecked Sendable {
         _lastSessionRecoveryToken = token
         tokenLock.unlock()
 
-        return (decryptedData, httpResponse)
+        let decryptedResponse = Self.stripContentLength(from: httpResponse)
+
+        return (decryptedData, decryptedResponse)
     }
 
     /// Makes an encrypted streaming request and returns chunks as an AsyncStream
@@ -214,6 +216,8 @@ public final class EHBPClient: @unchecked Sendable {
         _lastSessionRecoveryToken = token
         tokenLock.unlock()
 
+        let decryptedResponse = Self.stripContentLength(from: httpResponse)
+
         let stream = AsyncThrowingStream<Data, Error> { continuation in
             Task {
                 do {
@@ -263,9 +267,23 @@ public final class EHBPClient: @unchecked Sendable {
             }
         }
 
-        return (stream, httpResponse)
+        return (stream, decryptedResponse)
     }
 
+    private static func stripContentLength(from response: HTTPURLResponse) -> HTTPURLResponse {
+        var headers = [String: String]()
+        for (key, value) in response.allHeaderFields {
+            if let keyStr = key as? String, let valStr = value as? String, keyStr.lowercased() != "content-length" {
+                headers[keyStr] = valStr
+            }
+        }
+        return HTTPURLResponse(
+            url: response.url ?? URL(string: "about:blank")!,
+            statusCode: response.statusCode,
+            httpVersion: nil,
+            headerFields: headers
+        ) ?? response
+    }
 }
 
 // MARK: - Data Extensions


### PR DESCRIPTION
The original Content-Length reflects the encrypted payload size and is invalid after decryption, since the plaintext length differs. Remove the stale header in each client implementation to prevent consumers from misinterpreting the decrypted body length.

I think the go client change could fix tinfoilsh/tinfoil-proxy#17.

This needs to be tested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stale Content-Length headers from decrypted responses across Go, JS, Rust, and Swift clients so consumers don’t misread body size. This prevents incorrect buffering and streaming issues.

- **Bug Fixes**
  - Go: Delete Content-Length in DecryptResponseWithToken.
  - JS: Clone headers and delete `content-length` before creating the Response.
  - Rust: Remove `CONTENT_LENGTH` in both Response and StreamingResponse paths.
  - Swift: Add a helper to strip Content-Length and apply it to data and streaming responses.

<sup>Written for commit a103d8b530f4565674c633b1db28703be205e0be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

