### PR TITLE
Drop stale framing headers from decrypted responses

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -196,6 +199,100 @@ func TestTransportClearsRequestURI(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello, test", string(body))
+}
+
+// TestTransportBehindReverseProxyNonStreaming forwards a non-streaming reply
+// through httputil.ReverseProxy when the encrypted upstream response carries a
+// Content-Length header, as buffering middleboxes add when they re-frame the
+// server's chunked reply. That header describes the encrypted body; if the
+// transport leaves it on the decrypted response, the reverse proxy announces
+// more bytes than it writes and the downstream client sees a truncated reply.
+func TestTransportBehindReverseProxyNonStreaming(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+
+	const reply = "Hello from the enclave, this reply must arrive intact"
+
+	middleware := serverIdentity.Middleware()
+	mux := http.NewServeMux()
+	mux.HandleFunc(protocol.KeysPath, serverIdentity.ConfigHandler)
+	mux.Handle("/secure", middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(reply))
+	})))
+	backend := httptest.NewServer(mux)
+	defer backend.Close()
+
+	// Buffers each upstream response and re-frames it with an explicit
+	// Content-Length matching the encrypted body.
+	buffering := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req, err := http.NewRequest(r.Method, backend.URL+r.URL.Path, r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		req.Header = r.Header.Clone()
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		encryptedBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		for key, values := range resp.Header {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(encryptedBody)))
+		w.WriteHeader(resp.StatusCode)
+		_, _ = w.Write(encryptedBody)
+	}))
+	defer buffering.Close()
+
+	transport, err := NewTransport(buffering.URL)
+	assert.NoError(t, err)
+
+	t.Run("decrypted response drops encrypted framing", func(t *testing.T) {
+		req, err := http.NewRequest("POST", buffering.URL+"/secure", bytes.NewBufferString("test"))
+		assert.NoError(t, err)
+
+		resp, err := transport.RoundTrip(req)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		defer resp.Body.Close()
+
+		assert.Empty(t, resp.Header.Get("Content-Length"))
+		assert.Equal(t, int64(-1), resp.ContentLength)
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, reply, string(body))
+	})
+
+	t.Run("full reply reaches the reverse proxy client", func(t *testing.T) {
+		target, err := url.Parse(buffering.URL)
+		assert.NoError(t, err)
+		reverseProxy := httputil.NewSingleHostReverseProxy(target)
+		reverseProxy.Transport = transport
+		proxyServer := httptest.NewServer(reverseProxy)
+		defer proxyServer.Close()
+
+		resp, err := http.Post(proxyServer.URL+"/secure", "text/plain", bytes.NewBufferString("test"))
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, reply, string(body))
+	})
 }
 
 type recordingRoundTripper struct {

--- a/identity/session_recovery.go
+++ b/identity/session_recovery.go
@@ -106,6 +106,11 @@ func DecryptResponseWithToken(resp *http.Response, token *SessionRecoveryToken) 
 		eof:    false,
 	}
 	resp.ContentLength = -1
+	// Any Content-Length header describes the encrypted body, not the
+	// decrypted stream. Consumers that forward the response headers verbatim
+	// (for example httputil.ReverseProxy) would otherwise announce a body
+	// length that no longer matches what is written, truncating the reply.
+	resp.Header.Del("Content-Length")
 
 	return nil
 }

--- a/identity/session_recovery_test.go
+++ b/identity/session_recovery_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -128,6 +129,53 @@ func TestDecryptResponseWithTokenSingleChunk(t *testing.T) {
 
 	err = DecryptResponseWithToken(resp, token)
 	require.NoError(t, err)
+
+	decrypted, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, responseData, string(decrypted))
+}
+
+func TestDecryptResponseWithTokenClearsStaleContentLength(t *testing.T) {
+	serverIdentity, err := NewIdentity()
+	require.NoError(t, err)
+
+	responseData := "response from server"
+
+	req := httptest.NewRequest("POST", "/test", strings.NewReader("request"))
+	reqCtx, err := serverIdentity.EncryptRequestWithContext(req)
+	require.NoError(t, err)
+
+	token, err := ExtractSessionRecoveryToken(reqCtx)
+	require.NoError(t, err)
+
+	respCtx, err := serverIdentity.DecryptRequestWithContext(req)
+	require.NoError(t, err)
+	io.ReadAll(req.Body)
+
+	w := httptest.NewRecorder()
+	writer, err := serverIdentity.SetupDerivedResponseEncryption(w, respCtx)
+	require.NoError(t, err)
+	writer.Write([]byte(responseData))
+	writer.Flush()
+
+	// Buffering infrastructure between server and client can re-frame the
+	// chunked encrypted reply with an explicit Content-Length describing the
+	// encrypted body.
+	encryptedLength := w.Body.Len()
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", encryptedLength))
+
+	resp := &http.Response{
+		Header:        w.Header(),
+		Body:          io.NopCloser(bytes.NewReader(w.Body.Bytes())),
+		ContentLength: int64(encryptedLength),
+	}
+
+	err = DecryptResponseWithToken(resp, token)
+	require.NoError(t, err)
+
+	assert.Empty(t, resp.Header.Get("Content-Length"),
+		"stale encrypted Content-Length must not survive decryption")
+	assert.Equal(t, int64(-1), resp.ContentLength)
 
 	decrypted, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)

--- a/js/src/identity.ts
+++ b/js/src/identity.ts
@@ -382,10 +382,18 @@ export async function decryptResponseWithToken(
   const km = await deriveResponseKeys(token.exportedSecret, token.requestEnc, responseNonce);
   const decryptedStream = createDecryptStream(response.body, km);
 
+  // Framing headers describe the encrypted body, not the decrypted stream.
+  // Consumers that forward the response headers verbatim (for example a
+  // proxy) would otherwise announce a body length that no longer matches
+  // what is written, truncating the reply.
+  const headers = new Headers(response.headers);
+  headers.delete('content-length');
+  headers.delete('transfer-encoding');
+
   return new Response(decryptedStream, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
+    headers,
   });
 }
 

--- a/js/src/test/session-recovery.test.ts
+++ b/js/src/test/session-recovery.test.ts
@@ -348,6 +348,51 @@ describe('Session Recovery Token', () => {
       assert(decrypted.headers.has(PROTOCOL.RESPONSE_NONCE_HEADER));
     });
 
+    it('should drop stale encrypted framing headers', async () => {
+      const { identity, privateKey } = await generateTestKeys();
+      const request = new Request('https://server.test/api', {
+        method: 'POST',
+        body: 'hello',
+      });
+
+      const { request: encryptedRequest, context } =
+        await identity.encryptRequestWithContext(request);
+      assert(context);
+
+      const token = await extractSessionRecoveryToken(context);
+      const encryptedResponse = await buildEncryptedResponse(
+        encryptedRequest,
+        privateKey,
+        'full reply',
+      );
+
+      // Buffering infrastructure between server and client can re-frame the
+      // encrypted reply with framing headers describing the ciphertext.
+      const encryptedBytes = new Uint8Array(await encryptedResponse.arrayBuffer());
+      const staleResponse = new Response(toArrayBuffer(encryptedBytes), {
+        status: 200,
+        headers: {
+          [PROTOCOL.RESPONSE_NONCE_HEADER]:
+            encryptedResponse.headers.get(PROTOCOL.RESPONSE_NONCE_HEADER)!,
+          'content-length': String(encryptedBytes.byteLength),
+          'transfer-encoding': 'chunked',
+          'content-type': 'text/plain',
+        },
+      });
+
+      const decrypted = await decryptResponseWithToken(staleResponse, token);
+
+      assert.strictEqual(decrypted.headers.get('content-length'), null,
+        'stale encrypted content-length must not survive decryption');
+      assert.strictEqual(decrypted.headers.get('transfer-encoding'), null,
+        'stale transfer-encoding must not survive decryption');
+      assert.strictEqual(decrypted.headers.get('content-type'), 'text/plain');
+      assert(decrypted.headers.has(PROTOCOL.RESPONSE_NONCE_HEADER));
+
+      const text = await decrypted.text();
+      assert.strictEqual(text, 'full reply');
+    });
+
     it('should return the response as-is when body is null', async () => {
       const token: SessionRecoveryToken = {
         exportedSecret: new Uint8Array(32),

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -223,6 +223,8 @@ impl Client {
         };
         self.clear_session_recovery_token_if_current(&token);
 
+        let mut headers = headers;
+        strip_encrypted_framing_headers(&mut headers);
         Ok(Response {
             status,
             headers,
@@ -294,6 +296,8 @@ impl Client {
                 }
             };
 
+        let mut headers = headers;
+        strip_encrypted_framing_headers(&mut headers);
         Ok(StreamingResponse {
             status,
             headers,
@@ -540,6 +544,15 @@ fn clear_session_recovery_token_if_current(
             *guard = None;
         }
     }
+}
+
+/// Removes framing headers that describe the encrypted body. The decrypted
+/// body has a different length, so consumers that forward the response
+/// headers verbatim (for example a proxy) would otherwise announce a body
+/// length that no longer matches what is written, truncating the reply.
+fn strip_encrypted_framing_headers(headers: &mut HeaderMap) {
+    headers.remove(CONTENT_LENGTH);
+    headers.remove(TRANSFER_ENCODING);
 }
 
 fn response_nonce(headers: &HeaderMap) -> Result<Vec<u8>> {
@@ -1037,5 +1050,142 @@ mod tests {
         assert!(request.contains("transfer-encoding: chunked"));
         assert!(!request.contains("content-length:"));
         assert!(request.contains("ehbp-encapsulated-key:"));
+    }
+
+    // Emulates a server whose encrypted reply reaches the client with an
+    // explicit Content-Length, as buffering middleboxes produce when they
+    // re-frame the server's chunked response. The decrypted responses must
+    // not retain framing headers that describe the ciphertext, or consumers
+    // forwarding the headers verbatim (proxies) would truncate the reply.
+    #[tokio::test]
+    async fn decrypted_responses_drop_encrypted_framing_headers() {
+        use aes_gcm::{
+            aead::{Aead as _, KeyInit as _, Payload},
+            Aes256Gcm, Nonce,
+        };
+        use hpke::{
+            aead::AesGcm256,
+            kdf::HkdfSha256,
+            kem::{Kem as _, X25519HkdfSha256},
+            setup_receiver, Deserializable as _, OpModeR, Serializable as _,
+        };
+        use rand::{rngs::StdRng, SeedableRng as _};
+
+        use crate::derive::{compute_nonce, frame_chunk};
+        use crate::protocol::{EXPORT_LABEL, EXPORT_LENGTH, HPKE_REQUEST_INFO};
+
+        const REPLY: &[u8] = b"full reply from the enclave";
+
+        let mut csprng = StdRng::from_os_rng();
+        let (private_key, public_key) = X25519HkdfSha256::gen_keypair(&mut csprng);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            for _ in 0..2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut bytes = Vec::new();
+                let mut buf = [0u8; 1024];
+                loop {
+                    let n = socket.read(&mut buf).await.unwrap();
+                    if n == 0 {
+                        break;
+                    }
+                    bytes.extend_from_slice(&buf[..n]);
+                    if bytes.windows(5).any(|window| window == b"0\r\n\r\n") {
+                        break;
+                    }
+                }
+                let request = String::from_utf8_lossy(&bytes).to_string();
+                let enc_hex = request
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.trim()
+                            .eq_ignore_ascii_case("ehbp-encapsulated-key")
+                            .then(|| value.trim().to_string())
+                    })
+                    .expect("request must carry the encapsulated key header");
+                let request_enc = hex::decode(&enc_hex).unwrap();
+
+                let encapped_key =
+                    <X25519HkdfSha256 as hpke::kem::Kem>::EncappedKey::from_bytes(&request_enc)
+                        .unwrap();
+                let receiver = setup_receiver::<AesGcm256, HkdfSha256, X25519HkdfSha256>(
+                    &OpModeR::Base,
+                    &private_key,
+                    &encapped_key,
+                    HPKE_REQUEST_INFO,
+                )
+                .unwrap();
+                let mut exported_secret = vec![0u8; EXPORT_LENGTH];
+                receiver.export(EXPORT_LABEL, &mut exported_secret).unwrap();
+
+                let response_nonce = [3u8; RESPONSE_NONCE_LENGTH];
+                let key_material =
+                    derive_response_keys(&exported_secret, &request_enc, &response_nonce).unwrap();
+                let cipher = Aes256Gcm::new_from_slice(&key_material.key).unwrap();
+                let nonce = compute_nonce(&key_material.nonce_base, 0);
+                let ciphertext = cipher
+                    .encrypt(
+                        Nonce::from_slice(&nonce),
+                        Payload {
+                            msg: REPLY,
+                            aad: &[],
+                        },
+                    )
+                    .unwrap();
+                let body = frame_chunk(&ciphertext).unwrap();
+
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n{RESPONSE_NONCE_HEADER}: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    hex::encode(response_nonce),
+                    body.len(),
+                );
+                socket.write_all(header.as_bytes()).await.unwrap();
+                socket.write_all(&body).await.unwrap();
+            }
+        });
+
+        let identity = ServerIdentity::from_public_key_bytes(&public_key.to_bytes()).unwrap();
+        let client = Client::with_identity_and_http_client(
+            Url::parse(&format!("http://{addr}/")).unwrap(),
+            identity,
+            reqwest::Client::new(),
+        )
+        .unwrap();
+
+        let response = client
+            .post("/secure")
+            .unwrap()
+            .body("secret")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.body.as_ref(), REPLY);
+        assert!(response.headers.get(CONTENT_LENGTH).is_none());
+        assert!(response.headers.get(TRANSFER_ENCODING).is_none());
+        assert!(response.headers.get(RESPONSE_NONCE_HEADER).is_some());
+        assert_eq!(response.headers.get(CONTENT_TYPE).unwrap(), "text/plain");
+
+        let streaming = client
+            .post("/stream")
+            .unwrap()
+            .body("secret")
+            .send_stream()
+            .await
+            .unwrap();
+
+        assert!(streaming.headers.get(CONTENT_LENGTH).is_none());
+        assert!(streaming.headers.get(TRANSFER_ENCODING).is_none());
+
+        let mut body = streaming.body;
+        let mut collected = Vec::new();
+        while let Some(chunk) = body.next().await {
+            collected.extend_from_slice(&chunk.unwrap());
+        }
+        assert_eq!(collected, REPLY);
     }
 }

--- a/swift/Sources/EHBP/Client.swift
+++ b/swift/Sources/EHBP/Client.swift
@@ -122,7 +122,7 @@ public final class EHBPClient: @unchecked Sendable {
         _lastSessionRecoveryToken = token
         tokenLock.unlock()
 
-        return (decryptedData, httpResponse)
+        return (decryptedData, EHBPClient.sanitizedResponse(httpResponse))
     }
 
     /// Makes an encrypted streaming request and returns chunks as an AsyncStream
@@ -263,7 +263,32 @@ public final class EHBPClient: @unchecked Sendable {
             }
         }
 
-        return (stream, httpResponse)
+        return (stream, EHBPClient.sanitizedResponse(httpResponse))
+    }
+
+    /// Removes framing headers that describe the encrypted body. The
+    /// decrypted data has a different length, so consumers that forward the
+    /// response headers verbatim (for example a proxy) would otherwise
+    /// announce a body length that no longer matches what is written,
+    /// truncating the reply.
+    static func sanitizedResponse(_ response: HTTPURLResponse) -> HTTPURLResponse {
+        var headers: [String: String] = [:]
+        for (name, value) in response.allHeaderFields {
+            guard let name = name as? String, let value = value as? String else { continue }
+            let lowered = name.lowercased()
+            if lowered == "content-length" || lowered == "transfer-encoding" { continue }
+            headers[name] = value
+        }
+        guard let url = response.url,
+              let sanitized = HTTPURLResponse(
+                  url: url,
+                  statusCode: response.statusCode,
+                  httpVersion: nil,
+                  headerFields: headers
+              ) else {
+            return response
+        }
+        return sanitized
     }
 
 }

--- a/swift/Tests/EHBPTests/SessionRecoveryTests.swift
+++ b/swift/Tests/EHBPTests/SessionRecoveryTests.swift
@@ -380,4 +380,84 @@ final class SessionRecoveryTests: XCTestCase {
             encryptedData: encryptedBody
         ))
     }
+
+    // The encrypted reply carries framing headers describing the ciphertext,
+    // as buffering middleboxes produce. The decrypted response handed to the
+    // caller must not retain them, or consumers forwarding the headers
+    // verbatim (proxies) would truncate the reply.
+    func testDecryptedResponseDropsEncryptedFramingHeaders() async throws {
+        let serverPrivateKey = Curve25519.KeyAgreement.PrivateKey()
+
+        StubURLProtocol.handler = { [simulateServerResponse] request in
+            guard let encHex = request.value(forHTTPHeaderField: EHBPProtocol.encapsulatedKeyHeader),
+                  let requestEnc = Data(hexString: encHex) else {
+                throw EHBPError.invalidInput("missing encapsulated key header")
+            }
+            let (responseNonce, encryptedBody) = try simulateServerResponse(
+                serverPrivateKey, requestEnc, Data("full reply".utf8), nil
+            )
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: [
+                    EHBPProtocol.responseNonceHeader: responseNonce.hexString,
+                    "Content-Length": String(encryptedBody.count),
+                    "Transfer-Encoding": "identity",
+                    "Content-Type": "text/plain",
+                ]
+            )!
+            return (response, encryptedBody)
+        }
+        defer { StubURLProtocol.handler = nil }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+
+        let client = try EHBPClient(
+            baseURL: "https://server.test",
+            publicKey: Data(serverPrivateKey.publicKey.rawRepresentation),
+            session: session
+        )
+
+        let (data, response) = try await client.request(
+            method: "POST",
+            path: "/secure",
+            body: Data("hello".utf8)
+        )
+
+        XCTAssertEqual(String(data: data, encoding: .utf8), "full reply")
+        XCTAssertNil(response.value(forHTTPHeaderField: "Content-Length"),
+                     "stale encrypted Content-Length must not survive decryption")
+        XCTAssertNil(response.value(forHTTPHeaderField: "Transfer-Encoding"),
+                     "stale Transfer-Encoding must not survive decryption")
+        XCTAssertEqual(response.value(forHTTPHeaderField: "Content-Type"), "text/plain")
+        XCTAssertNotNil(response.value(forHTTPHeaderField: EHBPProtocol.responseNonceHeader))
+    }
+}
+
+final class StubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = StubURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: EHBPError.invalidInput("no stub handler"))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents truncated replies when forwarding decrypted responses by stripping stale framing headers that describe the encrypted body. Ensures full bodies reach clients and proxies like `httputil.ReverseProxy` across Go, JS, Rust, and Swift.

- Bug Fixes
  - Go: In `identity.DecryptResponseWithToken`, delete `Content-Length` and set `resp.ContentLength = -1`. Tests cover stale-length removal and full replies via `httputil.ReverseProxy`.
  - JS/Rust/Swift: Drop `content-length` and `transfer-encoding` on decrypted responses (including streaming) while preserving other headers. Added tests in each SDK to guard this behavior.

<sup>Written for commit 4c97234bccf8032f2d0c9669b469f3cf3b09c5fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

