### PR TITLE
Rust streaming transport + chores

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ehbp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ehbp",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@panva/hpke-noble": "^1.0.3",

--- a/js/package.json
+++ b/js/package.json
@@ -13,13 +13,15 @@
     }
   },
   "scripts": {
-    "build": "npm run build:esm && npm run build:cjs",
+    "clean": "node -e \"const fs = require('node:fs'); for (const dir of ['dist/esm', 'dist/cjs']) fs.rmSync(dir, { recursive: true, force: true })\"",
+    "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "build:esm": "tsc -p tsconfig.esm.json && echo '{\"type\":\"module\"}' > dist/esm/package.json",
     "build:cjs": "tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
     "build:browser": "node build-browser.js",
     "build:all": "npm run build && npm run build:browser",
     "dev": "tsc --watch",
-    "test": "node --test dist/esm/test/*.test.js",
+    "test": "npm run build && node --test dist/esm/test/*.test.js",
+    "prepack": "npm run build",
     "test:integration": "node dist/esm/test/streaming.integration.js",
     "example": "node --experimental-strip-types examples/example.ts",
     "serve": "node serve.js"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ehbp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "JavaScript client for Encrypted HTTP Body Protocol (EHBP)",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tinfoil-ehbp"
-version = "0.2.5"
+version = "0.2.6"
 description = "Python client for the encrypted HTTP body protocol"
 license = "MIT"
 requires-python = ">=3.9"

--- a/python/src/ehbp/__init__.py
+++ b/python/src/ehbp/__init__.py
@@ -23,7 +23,7 @@ from .identity import EncryptedRequest, ServerIdentity
 from .session import SessionRecoveryToken
 from .transport import AsyncEHBPTransport, EHBPTransport
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 __all__ = [
     "Client",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -66,6 +66,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +134,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -162,10 +187,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -266,6 +326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +380,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -408,9 +480,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -551,7 +634,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -702,6 +784,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +885,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +950,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
@@ -873,6 +1042,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -918,6 +1088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -973,14 +1149,15 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -993,7 +1170,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1031,12 +1207,24 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1050,11 +1238,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1067,10 +1283,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
+name = "same-file"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "sec1"
@@ -1083,6 +1311,29 @@ dependencies = [
  "generic-array",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1135,18 +1386,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,6 +1401,22 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1281,6 +1536,7 @@ dependencies = [
  "hkdf",
  "hpke",
  "http",
+ "http-body-util",
  "rand",
  "reqwest",
  "serde",
@@ -1443,6 +1699,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1749,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1569,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -1601,12 +1873,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.7"
+name = "webpki-root-certs"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -159,7 +159,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -169,7 +180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -237,6 +248,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,7 +295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version",
@@ -478,11 +498,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -492,8 +510,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -963,7 +984,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -975,7 +996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1038,15 +1059,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1104,6 +1126,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1162,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1392,7 +1440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1537,7 +1585,7 @@ dependencies = [
  "hpke",
  "http",
  "http-body-util",
- "rand",
+ "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "tinfoil-ehbp"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "aes-gcm",
  "async-stream",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,6 +13,7 @@ bytes = "1"
 futures-core = "0.3"
 hex = "0.4"
 hkdf = "0.12"
+http = "1"
 http-body-util = "0.1"
 hpke = "0.13"
 rand = { version = "0.9", default-features = false, features = ["os_rng", "std_rng"] }
@@ -26,6 +27,5 @@ zeroize = "1"
 
 [dev-dependencies]
 futures-util = "0.3"
-http = "1"
 reqwest = { version = "0.13", default-features = false, features = ["multipart", "rustls", "stream"] }
-tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinfoil-ehbp"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 rust-version = "1.87"
 description = "Rust client for the encrypted HTTP body protocol"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,9 +13,10 @@ bytes = "1"
 futures-core = "0.3"
 hex = "0.4"
 hkdf = "0.12"
+http-body-util = "0.1"
 hpke = "0.13"
 rand = { version = "0.9", default-features = false, features = ["os_rng", "std_rng"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
@@ -26,4 +27,5 @@ zeroize = "1"
 [dev-dependencies]
 futures-util = "0.3"
 http = "1"
+reqwest = { version = "0.13", default-features = false, features = ["multipart", "rustls", "stream"] }
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,11 @@ rust-version = "1.87"
 description = "Rust client for the encrypted HTTP body protocol"
 license = "MIT"
 
+[features]
+default = ["rustls-aws-lc"]
+rustls-aws-lc = ["reqwest/rustls"]
+rustls-no-provider = ["reqwest/rustls-no-provider"]
+
 [dependencies]
 aes-gcm = "0.10"
 async-stream = "0.3"
@@ -17,7 +22,7 @@ http = "1"
 http-body-util = "0.1"
 hpke = "0.13"
 rand = { version = "0.9", default-features = false, features = ["os_rng", "std_rng"] }
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
@@ -27,5 +32,5 @@ zeroize = "1"
 
 [dev-dependencies]
 futures-util = "0.3"
-reqwest = { version = "0.13", default-features = false, features = ["multipart", "rustls", "stream"] }
+reqwest = { version = "0.13", default-features = false, features = ["multipart", "stream"] }
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,5 +1,9 @@
 use bytes::{Buf, Bytes, BytesMut};
 use futures_core::Stream;
+#[cfg(not(target_arch = "wasm32"))]
+use http_body_util::BodyExt;
+#[cfg(not(target_arch = "wasm32"))]
+use reqwest::ResponseBuilderExt;
 use reqwest::{
     header::{
         HeaderMap, HeaderName, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE, HOST, TRANSFER_ENCODING,
@@ -162,6 +166,180 @@ impl Client {
 
     pub fn delete(&self, path_or_url: impl AsRef<str>) -> Result<RequestBuilder> {
         self.request(Method::DELETE, path_or_url)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn execute(&self, request: reqwest::Request) -> Result<reqwest::Response> {
+        let PreparedRawRequest { request, token } = self.prepare_raw_request(request).await?;
+        let mut guard = token.as_ref().map(|token| SessionGuard {
+            token: token.clone(),
+            session: Arc::clone(&self.last_session_recovery_token),
+            active: true,
+        });
+        let response = match self.http_client.execute(request).await {
+            Ok(response) => response,
+            Err(err) => return Err(err.into()),
+        };
+        let response = self.open_raw_response(response, token).await?;
+        if let Some(guard) = guard.as_mut() {
+            guard.disarm();
+        }
+        Ok(response)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn prepare_raw_request(
+        &self,
+        mut request: reqwest::Request,
+    ) -> Result<PreparedRawRequest> {
+        self.validate_raw_request(&request)?;
+        self.replace_session_recovery_token(None);
+
+        let Some(body) = request.body_mut().take() else {
+            return Ok(PreparedRawRequest {
+                request,
+                token: None,
+            });
+        };
+
+        let mut plaintext = Box::pin(body.into_data_stream());
+        let first_chunk = loop {
+            match std::future::poll_fn(|cx| plaintext.as_mut().poll_next(cx)).await {
+                Some(Ok(chunk)) if chunk.is_empty() => continue,
+                Some(chunk) => break chunk?,
+                None => {
+                    return Ok(PreparedRawRequest {
+                        request,
+                        token: None,
+                    });
+                }
+            }
+        };
+        let mut encryptor = self.identity.request_encryptor()?;
+        let encapsulated_key = hex::encode(&encryptor.encapsulated_key);
+        let token = encryptor.token.clone();
+        let encrypted: Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>> =
+            Box::pin(async_stream::try_stream! {
+                yield Bytes::from(encryptor.encrypt_chunk(&first_chunk)?);
+                while let Some(chunk) =
+                    std::future::poll_fn(|cx| plaintext.as_mut().poll_next(cx)).await
+                {
+                    let chunk = chunk?;
+                    if !chunk.is_empty() {
+                        yield Bytes::from(encryptor.encrypt_chunk(&chunk)?);
+                    }
+                }
+            });
+
+        request.headers_mut().insert(
+            header_name(ENCAPSULATED_KEY_HEADER)?,
+            HeaderValue::from_str(&encapsulated_key)?,
+        );
+        request.headers_mut().remove(CONTENT_LENGTH);
+        request.headers_mut().remove(TRANSFER_ENCODING);
+        *request.body_mut() = Some(reqwest::Body::wrap_stream(encrypted));
+        self.replace_session_recovery_token(Some(token.clone()));
+
+        Ok(PreparedRawRequest {
+            request,
+            token: Some(token),
+        })
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn open_raw_response(
+        &self,
+        mut response: reqwest::Response,
+        token: Option<SessionRecoveryToken>,
+    ) -> Result<reqwest::Response> {
+        let Some(token) = token else {
+            return Ok(response);
+        };
+
+        if !response.headers().contains_key(RESPONSE_NONCE_HEADER) {
+            let status = response.status();
+            let headers = response.headers().clone();
+            let body = match read_response_body_capped(response, DEFAULT_MAX_RESPONSE_BYTES).await {
+                Ok(body) => body,
+                Err(err) => {
+                    self.replace_session_recovery_token(None);
+                    return Err(err);
+                }
+            };
+            self.replace_session_recovery_token(None);
+            check_key_config_mismatch(status, &headers, &body)?;
+            return Err(Error::Protocol(format!(
+                "missing {RESPONSE_NONCE_HEADER} header"
+            )));
+        }
+
+        let response_nonce = match response_nonce(response.headers()) {
+            Ok(nonce) => nonce,
+            Err(err) => {
+                self.replace_session_recovery_token(None);
+                return Err(err);
+            }
+        };
+        let key_material =
+            match derive_response_keys(&token.exported_secret, &token.request_enc, &response_nonce)
+            {
+                Ok(key_material) => key_material,
+                Err(err) => {
+                    self.replace_session_recovery_token(None);
+                    return Err(err);
+                }
+            };
+        let status = response.status();
+        let version = response.version();
+        let url = response.url().clone();
+        let extensions = std::mem::take(response.extensions_mut());
+        let mut headers = response.headers().clone();
+        strip_encrypted_framing_headers(&mut headers);
+
+        let body = SessionClearingStream {
+            inner: Box::pin(decrypt_response_stream(
+                response.bytes_stream(),
+                key_material,
+            )),
+            token,
+            session: Arc::clone(&self.last_session_recovery_token),
+            cleared: false,
+        };
+        let mut builder = http::Response::builder().status(status).version(version);
+        if let Some(target) = builder.headers_mut() {
+            *target = headers;
+        }
+        if let Some(target) = builder.extensions_mut() {
+            *target = extensions;
+        }
+        let rebuilt = builder
+            .url(url)
+            .body(reqwest::Body::wrap_stream(body))
+            .map_err(|err| Error::Protocol(format!("failed to rebuild response: {err}")))?;
+        Ok(reqwest::Response::from(rebuilt))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn validate_raw_request(&self, request: &reqwest::Request) -> Result<()> {
+        if !same_origin(&self.base_url, request.url()) {
+            return Err(Error::InvalidInput(format!(
+                "request URL must use the configured origin: {}",
+                self.base_url.origin().ascii_serialization()
+            )));
+        }
+        if !request.url().username().is_empty() || request.url().password().is_some() {
+            return Err(Error::InvalidInput(
+                "request URL must not include credentials".into(),
+            ));
+        }
+        for name in request.headers().keys() {
+            if is_reserved_raw_request_header(name) {
+                return Err(Error::InvalidInput(format!(
+                    "reserved request header cannot be set by callers: {name}"
+                )));
+            }
+        }
+        Ok(())
     }
 
     async fn send_parts(
@@ -374,6 +552,12 @@ struct PreparedRequest {
     token: Option<SessionRecoveryToken>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+struct PreparedRawRequest {
+    request: reqwest::Request,
+    token: Option<SessionRecoveryToken>,
+}
+
 impl RequestBuilder {
     pub fn header<K, V>(mut self, name: K, value: V) -> Result<Self>
     where
@@ -529,6 +713,13 @@ fn is_reserved_request_header(name: &HeaderName) -> bool {
         || name.as_str().eq_ignore_ascii_case(RESPONSE_NONCE_HEADER)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+fn is_reserved_raw_request_header(name: &HeaderName) -> bool {
+    name == HOST
+        || name.as_str().eq_ignore_ascii_case(ENCAPSULATED_KEY_HEADER)
+        || name.as_str().eq_ignore_ascii_case(RESPONSE_NONCE_HEADER)
+}
+
 fn encrypted_reqwest_body(body: Vec<u8>) -> reqwest::Body {
     reqwest::Body::wrap_stream(async_stream::stream! {
         yield Ok::<Bytes, std::io::Error>(Bytes::from(body));
@@ -658,6 +849,29 @@ struct SessionClearingStream {
     token: SessionRecoveryToken,
     session: Arc<Mutex<Option<SessionRecoveryToken>>>,
     cleared: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct SessionGuard {
+    token: SessionRecoveryToken,
+    session: Arc<Mutex<Option<SessionRecoveryToken>>>,
+    active: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl SessionGuard {
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        if self.active {
+            clear_session_recovery_token_if_current(&self.session, &self.token);
+        }
+    }
 }
 
 impl SessionClearingStream {
@@ -889,6 +1103,379 @@ mod tests {
         .unwrap()
     }
 
+    type TestPrivateKey = <hpke::kem::X25519HkdfSha256 as hpke::kem::Kem>::PrivateKey;
+
+    fn raw_client_with_private_key() -> (Client, TestPrivateKey) {
+        use hpke::{
+            kem::{Kem as _, X25519HkdfSha256},
+            Serializable as _,
+        };
+        use rand::{rngs::StdRng, SeedableRng as _};
+
+        let mut csprng = StdRng::from_os_rng();
+        let (private_key, public_key) = X25519HkdfSha256::gen_keypair(&mut csprng);
+        let identity = ServerIdentity::from_public_key_bytes(&public_key.to_bytes()).unwrap();
+        let client = Client::with_identity_and_http_client(
+            Url::parse("https://example.com/").unwrap(),
+            identity,
+            reqwest::Client::new(),
+        )
+        .unwrap();
+        (client, private_key)
+    }
+
+    fn decrypt_request_frames(
+        private_key: &TestPrivateKey,
+        request_enc: &[u8],
+        framed: &[u8],
+    ) -> Vec<Vec<u8>> {
+        use hpke::{
+            aead::AesGcm256, kdf::HkdfSha256, kem::X25519HkdfSha256, setup_receiver,
+            Deserializable as _, OpModeR,
+        };
+
+        let encapped_key =
+            <X25519HkdfSha256 as hpke::kem::Kem>::EncappedKey::from_bytes(request_enc).unwrap();
+        let mut receiver = setup_receiver::<AesGcm256, HkdfSha256, X25519HkdfSha256>(
+            &OpModeR::Base,
+            private_key,
+            &encapped_key,
+            crate::protocol::HPKE_REQUEST_INFO,
+        )
+        .unwrap();
+        let mut offset = 0usize;
+        let mut plaintext = Vec::new();
+
+        while offset < framed.len() {
+            let chunk_len = u32::from_be_bytes(
+                framed[offset..offset + 4]
+                    .try_into()
+                    .expect("frame must include a length"),
+            ) as usize;
+            offset += 4;
+            let chunk = &framed[offset..offset + chunk_len];
+            offset += chunk_len;
+            plaintext.push(receiver.open(chunk, &[]).unwrap());
+        }
+
+        plaintext
+    }
+
+    #[tokio::test]
+    async fn raw_transport_encrypts_streaming_request_chunks() {
+        let (client, private_key) = raw_client_with_private_key();
+        let plaintext = stream::iter([
+            Ok::<Bytes, std::io::Error>(Bytes::from_static(b"first")),
+            Ok(Bytes::new()),
+            Ok(Bytes::from_static(b"second")),
+        ]);
+        let request = reqwest::Client::new()
+            .post("https://example.com/v1/audio")
+            .body(reqwest::Body::wrap_stream(plaintext))
+            .build()
+            .unwrap();
+
+        let mut prepared = client.prepare_raw_request(request).await.unwrap();
+        let token = prepared.token.unwrap();
+        let request_enc = hex::decode(
+            prepared.request.headers()[ENCAPSULATED_KEY_HEADER]
+                .to_str()
+                .unwrap(),
+        )
+        .unwrap();
+        let body = prepared
+            .request
+            .body_mut()
+            .take()
+            .unwrap()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+
+        assert_eq!(request_enc, token.request_enc);
+        assert!(prepared.request.headers().get(CONTENT_LENGTH).is_none());
+        assert_eq!(
+            decrypt_request_frames(&private_key, &request_enc, &body),
+            [b"first".to_vec(), b"second".to_vec()]
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_transport_encrypts_streaming_multipart_requests() {
+        let (client, private_key) = raw_client_with_private_key();
+        let file = stream::iter([
+            Ok::<Bytes, std::io::Error>(Bytes::from_static(b"audio-")),
+            Ok(Bytes::from_static(b"payload")),
+        ]);
+        let form = reqwest::multipart::Form::new()
+            .text("model", "gpt-oss-120b")
+            .part(
+                "file",
+                reqwest::multipart::Part::stream(reqwest::Body::wrap_stream(file))
+                    .file_name("sample.wav"),
+            );
+        let request = reqwest::Client::new()
+            .post("https://example.com/v1/audio/transcriptions")
+            .multipart(form)
+            .build()
+            .unwrap();
+
+        let mut prepared = client.prepare_raw_request(request).await.unwrap();
+        let request_enc = hex::decode(
+            prepared.request.headers()[ENCAPSULATED_KEY_HEADER]
+                .to_str()
+                .unwrap(),
+        )
+        .unwrap();
+        let body = prepared
+            .request
+            .body_mut()
+            .take()
+            .unwrap()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+        let chunks = decrypt_request_frames(&private_key, &request_enc, &body);
+        let plaintext = chunks.concat();
+        let plaintext = String::from_utf8(plaintext).unwrap();
+
+        assert!(chunks.len() > 1);
+        assert!(plaintext.contains("name=\"model\""));
+        assert!(plaintext.contains("gpt-oss-120b"));
+        assert!(plaintext.contains("filename=\"sample.wav\""));
+        assert!(plaintext.contains("audio-payload"));
+        assert!(prepared.request.headers().get(CONTENT_LENGTH).is_none());
+        assert!(prepared.request.headers().get(CONTENT_TYPE).is_some());
+    }
+
+    #[tokio::test]
+    async fn raw_transport_preserves_decrypted_response_metadata() {
+        use aes_gcm::{
+            aead::{Aead as _, KeyInit as _, Payload},
+            Aes256Gcm, Nonce,
+        };
+
+        #[derive(Clone, Debug, PartialEq)]
+        struct Marker(u8);
+
+        let (client, _) = raw_client_with_private_key();
+        let request = reqwest::Client::new()
+            .post("https://example.com/v1/chat")
+            .body("secret")
+            .build()
+            .unwrap();
+        let prepared = client.prepare_raw_request(request).await.unwrap();
+        let token = prepared.token.unwrap();
+        let response_nonce = [9u8; RESPONSE_NONCE_LENGTH];
+        let key_material =
+            derive_response_keys(&token.exported_secret, &token.request_enc, &response_nonce)
+                .unwrap();
+        let cipher = Aes256Gcm::new_from_slice(&key_material.key).unwrap();
+        let nonce = crate::derive::compute_nonce(&key_material.nonce_base, 0);
+        let ciphertext = cipher
+            .encrypt(
+                Nonce::from_slice(&nonce),
+                Payload {
+                    msg: b"decrypted reply",
+                    aad: &[],
+                },
+            )
+            .unwrap();
+        let body = crate::derive::frame_chunk(&ciphertext).unwrap();
+        let url = Url::parse("https://example.com/v1/chat").unwrap();
+        let response = http::Response::builder()
+            .status(StatusCode::OK)
+            .url(url.clone())
+            .header(CONTENT_TYPE, "text/plain")
+            .header(CONTENT_LENGTH, body.len())
+            .header(RESPONSE_NONCE_HEADER, hex::encode(response_nonce))
+            .body(reqwest::Body::from(body))
+            .unwrap();
+        let mut response = reqwest::Response::from(response);
+        response.extensions_mut().insert(Marker(7));
+
+        let response = client
+            .open_raw_response(response, Some(token))
+            .await
+            .unwrap();
+
+        assert_eq!(response.url(), &url);
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.extensions().get::<Marker>(), Some(&Marker(7)));
+        assert_eq!(response.headers()[CONTENT_TYPE], "text/plain");
+        assert!(response.headers().get(CONTENT_LENGTH).is_none());
+        assert!(client.get_session_recovery_token().is_some());
+        assert_eq!(response.bytes().await.unwrap(), "decrypted reply");
+        assert!(client.get_session_recovery_token().is_none());
+    }
+
+    #[tokio::test]
+    async fn raw_transport_returns_typed_key_config_mismatch() {
+        let (client, _) = raw_client_with_private_key();
+        let request = reqwest::Client::new()
+            .post("https://example.com/v1/chat")
+            .body("secret")
+            .build()
+            .unwrap();
+        let prepared = client.prepare_raw_request(request).await.unwrap();
+        let response = http::Response::builder()
+            .status(StatusCode::UNPROCESSABLE_ENTITY)
+            .header(CONTENT_TYPE, "Application/Problem+Json; charset=utf-8")
+            .body(reqwest::Body::from(format!(
+                r#"{{"type":"{KEY_CONFIG_PROBLEM_TYPE}","title":"rotate key"}}"#
+            )))
+            .unwrap();
+        let response = reqwest::Response::from(response);
+
+        let err = client
+            .open_raw_response(response, prepared.token)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::KeyConfigMismatch(title) if title == "rotate key"));
+        assert!(client.get_session_recovery_token().is_none());
+    }
+
+    #[tokio::test]
+    async fn raw_transport_rejects_unsafe_request_identity() {
+        let (client, _) = raw_client_with_private_key();
+        let cross_origin = reqwest::Client::new()
+            .post("https://evil.example/v1/chat")
+            .body("secret")
+            .build()
+            .unwrap();
+        assert!(client.prepare_raw_request(cross_origin).await.is_err());
+
+        let reserved_header = reqwest::Client::new()
+            .post("https://example.com/v1/chat")
+            .header(ENCAPSULATED_KEY_HEADER, "00")
+            .body("secret")
+            .build()
+            .unwrap();
+        assert!(client.prepare_raw_request(reserved_header).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn raw_transport_leaves_bodyless_requests_unencrypted() {
+        let (client, _) = raw_client_with_private_key();
+        let request = reqwest::Client::new()
+            .get("https://example.com/v1/models")
+            .build()
+            .unwrap();
+
+        let prepared = client.prepare_raw_request(request).await.unwrap();
+
+        assert!(prepared.token.is_none());
+        assert!(prepared.request.body().is_none());
+        assert!(prepared
+            .request
+            .headers()
+            .get(ENCAPSULATED_KEY_HEADER)
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn raw_transport_propagates_request_stream_errors() {
+        #[derive(Debug)]
+        struct StreamError;
+
+        impl std::fmt::Display for StreamError {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("request stream failed")
+            }
+        }
+
+        impl std::error::Error for StreamError {}
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buffer = [0u8; 1024];
+            while socket.read(&mut buffer).await.unwrap_or_default() != 0 {}
+        });
+
+        let identity = ServerIdentity::from_public_key_bytes(&[7u8; 32]).unwrap();
+        let client = Client::with_identity_and_http_client(
+            Url::parse(&format!("http://{addr}/")).unwrap(),
+            identity,
+            reqwest::Client::new(),
+        )
+        .unwrap();
+        let body = stream::iter([
+            Ok::<Bytes, StreamError>(Bytes::from_static(b"first")),
+            Err(StreamError),
+        ]);
+        let request = reqwest::Client::new()
+            .post(format!("http://{addr}/secure"))
+            .body(reqwest::Body::wrap_stream(body))
+            .build()
+            .unwrap();
+
+        assert!(client.execute(request).await.is_err());
+        assert!(client.get_session_recovery_token().is_none());
+    }
+
+    #[tokio::test]
+    async fn cancelling_raw_transport_clears_session_recovery_token() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let request_received = Arc::new(tokio::sync::Notify::new());
+        let request_received_by_server = Arc::clone(&request_received);
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buffer = [0u8; 1024];
+            let _ = socket.read(&mut buffer).await.unwrap();
+            request_received_by_server.notify_one();
+            std::future::pending::<()>().await;
+        });
+
+        let identity = ServerIdentity::from_public_key_bytes(&[7u8; 32]).unwrap();
+        let client = Client::with_identity_and_http_client(
+            Url::parse(&format!("http://{addr}/")).unwrap(),
+            identity,
+            reqwest::Client::new(),
+        )
+        .unwrap();
+        let request = reqwest::Client::new()
+            .post(format!("http://{addr}/secure"))
+            .body("secret")
+            .build()
+            .unwrap();
+        let client_for_request = client.clone();
+        let request_task = tokio::spawn(async move { client_for_request.execute(request).await });
+
+        request_received.notified().await;
+        assert!(client.get_session_recovery_token().is_some());
+        request_task.abort();
+        let _ = request_task.await;
+
+        assert!(client.get_session_recovery_token().is_none());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn raw_transport_uses_fresh_contexts_for_rebuilt_requests() {
+        let (client, _) = raw_client_with_private_key();
+        let build_request = || {
+            reqwest::Client::new()
+                .post("https://example.com/v1/chat")
+                .body("same plaintext")
+                .build()
+                .unwrap()
+        };
+
+        let first = client.prepare_raw_request(build_request()).await.unwrap();
+        let second = client.prepare_raw_request(build_request()).await.unwrap();
+
+        assert_ne!(
+            first.request.headers()[ENCAPSULATED_KEY_HEADER],
+            second.request.headers()[ENCAPSULATED_KEY_HEADER]
+        );
+    }
+
     async fn serve_key_config(content_type: &'static str) -> String {
         let identity = ServerIdentity::from_public_key_bytes(&[7u8; 32]).unwrap();
         let config = identity.marshal_public_config();
@@ -1008,7 +1595,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn encrypted_requests_omit_content_length() {
+    async fn raw_execute_encrypts_requests_without_content_length() {
         let captured = Arc::new(Mutex::new(String::new()));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -1044,7 +1631,12 @@ mod tests {
         )
         .unwrap();
 
-        let _ = client.post("/secure").unwrap().body("secret").send().await;
+        let request = reqwest::Client::new()
+            .post(format!("http://{addr}/secure"))
+            .body("secret")
+            .build()
+            .unwrap();
+        let _ = client.execute(request).await;
 
         let request = captured.lock().unwrap().to_ascii_lowercase();
         assert!(request.contains("transfer-encoding: chunked"));

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -171,10 +171,8 @@ impl Client {
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn execute(&self, request: reqwest::Request) -> Result<reqwest::Response> {
         let PreparedRawRequest { request, token } = self.prepare_raw_request(request).await?;
-        let mut guard = token.as_ref().map(|token| SessionGuard {
-            token: token.clone(),
-            session: Arc::clone(&self.last_session_recovery_token),
-            active: true,
+        let mut guard = token.as_ref().map(|token| {
+            SessionGuard::new(token.clone(), Arc::clone(&self.last_session_recovery_token))
         });
         let response = match self.http_client.execute(request).await {
             Ok(response) => response,
@@ -256,47 +254,49 @@ impl Client {
             return Ok(response);
         };
 
-        if !response.headers().contains_key(RESPONSE_NONCE_HEADER) {
-            let status = response.status();
-            let headers = response.headers().clone();
-            let body = match read_response_body_capped(response, DEFAULT_MAX_RESPONSE_BYTES).await {
-                Ok(body) => body,
-                Err(err) => {
-                    self.replace_session_recovery_token(None);
-                    return Err(err);
-                }
-            };
-            self.replace_session_recovery_token(None);
+        let version = response.version();
+        let url = response.url().clone();
+        let extensions = std::mem::take(response.extensions_mut());
+        let opened = self.open_encrypted_response(response, token).await?;
+        let mut builder = http::Response::builder()
+            .status(opened.status)
+            .version(version);
+        if let Some(target) = builder.headers_mut() {
+            *target = opened.headers;
+        }
+        if let Some(target) = builder.extensions_mut() {
+            *target = extensions;
+        }
+        let rebuilt = builder
+            .url(url)
+            .body(reqwest::Body::wrap_stream(opened.body))
+            .map_err(|err| Error::Protocol(format!("failed to rebuild response: {err}")))?;
+        Ok(reqwest::Response::from(rebuilt))
+    }
+
+    async fn open_encrypted_response(
+        &self,
+        response: reqwest::Response,
+        token: SessionRecoveryToken,
+    ) -> Result<OpenedEncryptedResponse> {
+        let mut guard =
+            SessionGuard::new(token.clone(), Arc::clone(&self.last_session_recovery_token));
+        let status = response.status();
+        let mut headers = response.headers().clone();
+
+        if !headers.contains_key(RESPONSE_NONCE_HEADER) {
+            let body = read_response_body_capped(response, DEFAULT_MAX_RESPONSE_BYTES).await?;
             check_key_config_mismatch(status, &headers, &body)?;
             return Err(Error::Protocol(format!(
                 "missing {RESPONSE_NONCE_HEADER} header"
             )));
         }
 
-        let response_nonce = match response_nonce(response.headers()) {
-            Ok(nonce) => nonce,
-            Err(err) => {
-                self.replace_session_recovery_token(None);
-                return Err(err);
-            }
-        };
+        let response_nonce = response_nonce(&headers)?;
         let key_material =
-            match derive_response_keys(&token.exported_secret, &token.request_enc, &response_nonce)
-            {
-                Ok(key_material) => key_material,
-                Err(err) => {
-                    self.replace_session_recovery_token(None);
-                    return Err(err);
-                }
-            };
-        let status = response.status();
-        let version = response.version();
-        let url = response.url().clone();
-        let extensions = std::mem::take(response.extensions_mut());
-        let mut headers = response.headers().clone();
+            derive_response_keys(&token.exported_secret, &token.request_enc, &response_nonce)?;
         strip_encrypted_framing_headers(&mut headers);
-
-        let body = SessionClearingStream {
+        let body = Box::pin(SessionClearingStream {
             inner: Box::pin(decrypt_response_stream(
                 response.bytes_stream(),
                 key_material,
@@ -304,34 +304,19 @@ impl Client {
             token,
             session: Arc::clone(&self.last_session_recovery_token),
             cleared: false,
-        };
-        let mut builder = http::Response::builder().status(status).version(version);
-        if let Some(target) = builder.headers_mut() {
-            *target = headers;
-        }
-        if let Some(target) = builder.extensions_mut() {
-            *target = extensions;
-        }
-        let rebuilt = builder
-            .url(url)
-            .body(reqwest::Body::wrap_stream(body))
-            .map_err(|err| Error::Protocol(format!("failed to rebuild response: {err}")))?;
-        Ok(reqwest::Response::from(rebuilt))
+        });
+        guard.disarm();
+
+        Ok(OpenedEncryptedResponse {
+            status,
+            headers,
+            body,
+        })
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     fn validate_raw_request(&self, request: &reqwest::Request) -> Result<()> {
-        if !same_origin(&self.base_url, request.url()) {
-            return Err(Error::InvalidInput(format!(
-                "request URL must use the configured origin: {}",
-                self.base_url.origin().ascii_serialization()
-            )));
-        }
-        if !request.url().username().is_empty() || request.url().password().is_some() {
-            return Err(Error::InvalidInput(
-                "request URL must not include credentials".into(),
-            ));
-        }
+        self.validate_request_url(request.url())?;
         for name in request.headers().keys() {
             if is_reserved_raw_request_header(name) {
                 return Err(Error::InvalidInput(format!(
@@ -351,26 +336,13 @@ impl Client {
     ) -> Result<Response> {
         let PreparedRequest { request, token } =
             self.prepare_request_builder(method, url, headers, body)?;
-        let response = match request.send().await {
-            Ok(response) => response,
-            Err(err) => {
-                if token.is_some() {
-                    self.replace_session_recovery_token(None);
-                }
-                return Err(err.into());
-            }
-        };
+        let mut guard = token.as_ref().map(|token| {
+            SessionGuard::new(token.clone(), Arc::clone(&self.last_session_recovery_token))
+        });
+        let response = request.send().await?;
         let status = response.status();
         let headers = response.headers().clone();
-        let body = match read_response_body_capped(response, DEFAULT_MAX_RESPONSE_BYTES).await {
-            Ok(body) => body,
-            Err(err) => {
-                if token.is_some() {
-                    self.replace_session_recovery_token(None);
-                }
-                return Err(err);
-            }
-        };
+        let body = read_response_body_capped(response, DEFAULT_MAX_RESPONSE_BYTES).await?;
 
         let Some(token) = token else {
             return Ok(Response {
@@ -380,26 +352,13 @@ impl Client {
             });
         };
 
-        if let Err(err) = check_key_config_mismatch(status, &headers, &body) {
-            self.replace_session_recovery_token(None);
-            return Err(err);
-        }
-
-        let response_nonce = match response_nonce(&headers) {
-            Ok(nonce) => nonce,
-            Err(err) => {
-                self.replace_session_recovery_token(None);
-                return Err(err);
-            }
-        };
-        let decrypted = match token.decrypt_response_body(&response_nonce, &body) {
-            Ok(decrypted) => decrypted,
-            Err(err) => {
-                self.replace_session_recovery_token(None);
-                return Err(err);
-            }
-        };
+        check_key_config_mismatch(status, &headers, &body)?;
+        let response_nonce = response_nonce(&headers)?;
+        let decrypted = token.decrypt_response_body(&response_nonce, &body)?;
         self.clear_session_recovery_token_if_current(&token);
+        if let Some(guard) = guard.as_mut() {
+            guard.disarm();
+        }
 
         let mut headers = headers;
         strip_encrypted_framing_headers(&mut headers);
@@ -419,75 +378,27 @@ impl Client {
     ) -> Result<StreamingResponse> {
         let PreparedRequest { request, token } =
             self.prepare_request_builder(method, url, headers, body)?;
-        let response = match request.send().await {
-            Ok(response) => response,
-            Err(err) => {
-                if token.is_some() {
-                    self.replace_session_recovery_token(None);
-                }
-                return Err(err.into());
-            }
-        };
-        let status = response.status();
-        let headers = response.headers().clone();
+        let mut guard = token.as_ref().map(|token| {
+            SessionGuard::new(token.clone(), Arc::clone(&self.last_session_recovery_token))
+        });
+        let response = request.send().await?;
 
         let Some(token) = token else {
             return Ok(StreamingResponse {
-                status,
-                headers,
+                status: response.status(),
+                headers: response.headers().clone(),
                 body: Box::pin(response.bytes_stream().map_reqwest_error()),
             });
         };
 
-        if !headers.contains_key(RESPONSE_NONCE_HEADER) {
-            let body = match read_response_body_capped(response, DEFAULT_MAX_RESPONSE_BYTES).await {
-                Ok(body) => body,
-                Err(err) => {
-                    self.replace_session_recovery_token(None);
-                    return Err(err);
-                }
-            };
-            if let Err(err) = check_key_config_mismatch(status, &headers, &body) {
-                self.replace_session_recovery_token(None);
-                return Err(err);
-            }
-            self.replace_session_recovery_token(None);
-            return Err(Error::Protocol(format!(
-                "missing {RESPONSE_NONCE_HEADER} header"
-            )));
+        let opened = self.open_encrypted_response(response, token).await?;
+        if let Some(guard) = guard.as_mut() {
+            guard.disarm();
         }
-
-        let response_nonce = match response_nonce(&headers) {
-            Ok(nonce) => nonce,
-            Err(err) => {
-                self.replace_session_recovery_token(None);
-                return Err(err);
-            }
-        };
-        let key_material =
-            match derive_response_keys(&token.exported_secret, &token.request_enc, &response_nonce)
-            {
-                Ok(key_material) => key_material,
-                Err(err) => {
-                    self.replace_session_recovery_token(None);
-                    return Err(err);
-                }
-            };
-
-        let mut headers = headers;
-        strip_encrypted_framing_headers(&mut headers);
         Ok(StreamingResponse {
-            status,
-            headers,
-            body: Box::pin(SessionClearingStream {
-                inner: Box::pin(decrypt_response_stream(
-                    response.bytes_stream(),
-                    key_material,
-                )),
-                token,
-                session: Arc::clone(&self.last_session_recovery_token),
-                cleared: false,
-            }),
+            status: opened.status,
+            headers: opened.headers,
+            body: opened.body,
         })
     }
 
@@ -524,7 +435,12 @@ impl Client {
 
     fn resolve_url(&self, path_or_url: &str) -> Result<Url> {
         let url = self.base_url.join(path_or_url)?;
-        if !same_origin(&self.base_url, &url) {
+        self.validate_request_url(&url)?;
+        Ok(url)
+    }
+
+    fn validate_request_url(&self, url: &Url) -> Result<()> {
+        if !same_origin(&self.base_url, url) {
             return Err(Error::InvalidInput(format!(
                 "request URL must use the configured origin: {}",
                 self.base_url.origin().ascii_serialization()
@@ -535,7 +451,7 @@ impl Client {
                 "request URL must not include credentials".into(),
             ));
         }
-        Ok(url)
+        Ok(())
     }
 }
 
@@ -556,6 +472,12 @@ struct PreparedRequest {
 struct PreparedRawRequest {
     request: reqwest::Request,
     token: Option<SessionRecoveryToken>,
+}
+
+struct OpenedEncryptedResponse {
+    status: StatusCode,
+    headers: HeaderMap,
+    body: Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>,
 }
 
 impl RequestBuilder {
@@ -851,21 +773,26 @@ struct SessionClearingStream {
     cleared: bool,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 struct SessionGuard {
     token: SessionRecoveryToken,
     session: Arc<Mutex<Option<SessionRecoveryToken>>>,
     active: bool,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl SessionGuard {
+    fn new(token: SessionRecoveryToken, session: Arc<Mutex<Option<SessionRecoveryToken>>>) -> Self {
+        Self {
+            token,
+            session,
+            active: true,
+        }
+    }
+
     fn disarm(&mut self) {
         self.active = false;
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl Drop for SessionGuard {
     fn drop(&mut self) {
         if self.active {
@@ -1339,6 +1266,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn older_raw_response_error_preserves_newer_recovery_token() {
+        let (client, _) = raw_client_with_private_key();
+        let build_request = || {
+            reqwest::Client::new()
+                .post("https://example.com/v1/chat")
+                .body("secret")
+                .build()
+                .unwrap()
+        };
+        let first = client.prepare_raw_request(build_request()).await.unwrap();
+        let first_token = first.token.unwrap();
+        let second = client.prepare_raw_request(build_request()).await.unwrap();
+        let second_token = second.token.unwrap();
+        let response = reqwest::Response::from(
+            http::Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .body(reqwest::Body::from("missing nonce"))
+                .unwrap(),
+        );
+
+        let err = client
+            .open_raw_response(response, Some(first_token))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::Protocol(message) if message.contains("missing")
+        ));
+        assert_eq!(
+            client.get_session_recovery_token().as_ref(),
+            Some(&second_token)
+        );
+    }
+
+    #[tokio::test]
     async fn raw_transport_rejects_unsafe_request_identity() {
         let (client, _) = raw_client_with_private_key();
         let cross_origin = reqwest::Client::new()
@@ -1347,6 +1310,12 @@ mod tests {
             .build()
             .unwrap();
         assert!(client.prepare_raw_request(cross_origin).await.is_err());
+
+        let credential_url = reqwest::Request::new(
+            Method::POST,
+            Url::parse("https://user@example.com/v1/chat").unwrap(),
+        );
+        assert!(client.prepare_raw_request(credential_url).await.is_err());
 
         let reserved_header = reqwest::Client::new()
             .post("https://example.com/v1/chat")

--- a/rust/src/identity.rs
+++ b/rust/src/identity.rs
@@ -1,5 +1,5 @@
 use hpke::{
-    aead::AesGcm256,
+    aead::{AeadCtxS, AesGcm256},
     kdf::HkdfSha256,
     kem::{Kem, X25519HkdfSha256},
     setup_sender, Deserializable, OpModeS, Serializable,
@@ -78,7 +78,7 @@ impl ServerIdentity {
                 "no cipher suites found in config".into(),
             ));
         }
-        if suites_len % 4 != 0 {
+        if !suites_len.is_multiple_of(4) {
             return Err(Error::InvalidConfig(
                 "cipher suites length must be a multiple of 4".into(),
             ));
@@ -131,19 +131,25 @@ impl ServerIdentity {
             return Ok(None);
         }
 
+        let mut encryptor = self.request_encryptor()?;
+        let body = encryptor.encrypt_chunk(plaintext)?;
+
+        Ok(Some(EncryptedRequest {
+            encapsulated_key: encryptor.encapsulated_key,
+            body,
+            token: encryptor.token,
+        }))
+    }
+
+    pub(crate) fn request_encryptor(&self) -> Result<RequestEncryptor> {
         let mut csprng = StdRng::from_os_rng();
-        let (enc, mut sender) = setup_sender::<Aead, Kdf, KemSuite, _>(
+        let (enc, sender) = setup_sender::<Aead, Kdf, KemSuite, _>(
             &OpModeS::Base,
             &self.public_key,
             HPKE_REQUEST_INFO,
             &mut csprng,
         )
         .map_err(|err| Error::Hpke(format!("failed to set up sender: {err:?}")))?;
-
-        let ciphertext = sender
-            .seal(plaintext, &[])
-            .map_err(|err| Error::Hpke(format!("failed to seal request body: {err:?}")))?;
-        let body = frame_chunk(&ciphertext)?;
 
         let mut exported_secret = vec![0u8; EXPORT_LENGTH];
         sender
@@ -153,11 +159,27 @@ impl ServerIdentity {
         let request_enc = enc.to_bytes().to_vec();
         let token = SessionRecoveryToken::new(exported_secret, request_enc.clone())?;
 
-        Ok(Some(EncryptedRequest {
+        Ok(RequestEncryptor {
             encapsulated_key: request_enc,
-            body,
             token,
-        }))
+            sender,
+        })
+    }
+}
+
+pub(crate) struct RequestEncryptor {
+    pub encapsulated_key: Vec<u8>,
+    pub token: SessionRecoveryToken,
+    sender: AeadCtxS<Aead, Kdf, KemSuite>,
+}
+
+impl RequestEncryptor {
+    pub fn encrypt_chunk(&mut self, plaintext: &[u8]) -> Result<Vec<u8>> {
+        let ciphertext = self
+            .sender
+            .seal(plaintext, &[])
+            .map_err(|err| Error::Hpke(format!("failed to seal request body: {err:?}")))?;
+        frame_chunk(&ciphertext)
     }
 }
 
@@ -233,5 +255,36 @@ mod tests {
         };
 
         assert!(identity.encrypt_request_body(b"").unwrap().is_none());
+    }
+
+    #[test]
+    fn encrypts_multiple_request_chunks_in_one_context() {
+        let mut csprng = StdRng::from_os_rng();
+        let (private_key, public_key) = KemSuite::gen_keypair(&mut csprng);
+        let identity = ServerIdentity {
+            key_id: KEY_ID,
+            public_key,
+        };
+        let mut encryptor = identity.request_encryptor().unwrap();
+        let first = encryptor.encrypt_chunk(b"hello ").unwrap();
+        let second = encryptor.encrypt_chunk(b"stream").unwrap();
+
+        let encapped_key =
+            <KemSuite as Kem>::EncappedKey::from_bytes(&encryptor.encapsulated_key).unwrap();
+        let mut receiver = setup_receiver::<Aead, Kdf, KemSuite>(
+            &OpModeR::Base,
+            &private_key,
+            &encapped_key,
+            HPKE_REQUEST_INFO,
+        )
+        .unwrap();
+
+        let open = |receiver: &mut hpke::aead::AeadCtxR<Aead, Kdf, KemSuite>, frame: &[u8]| {
+            let chunk_len = u32::from_be_bytes([frame[0], frame[1], frame[2], frame[3]]) as usize;
+            receiver.open(&frame[4..4 + chunk_len], &[]).unwrap()
+        };
+
+        assert_eq!(open(&mut receiver, &first), b"hello ");
+        assert_eq!(open(&mut receiver, &second), b"stream");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds encrypted streaming transport to the Rust client, with per‑chunk HPKE for requests and streamed response decryption. Also makes the Rust TLS provider configurable and fixes JS packaging to avoid stale builds.

- **New Features**
  - Added `Client::execute` (non-`wasm32`) to send raw `reqwest::Request` with per‑chunk HPKE; supports streaming bodies and multipart; strips `Content-Length` and `Transfer-Encoding`.
  - Validates same-origin and rejects reserved headers (`Host`, encapsulated key, response nonce).
  - Decrypts streaming responses using `RESPONSE_NONCE_HEADER`; rebuilds responses preserving status, headers, URL, and extensions; strips framing headers; returns typed `KeyConfigMismatch`.
  - Upgraded to `reqwest@0.13` and made TLS provider configurable via features: default `rustls-aws-lc`, optional `rustls-no-provider`.

- **Bug Fixes**
  - Preserve recovery state across concurrent in-flight requests; older failures no longer clear a newer token.
  - Clear recovery token on request stream errors and task cancellation.
  - JS: add clean step and `prepack` build to prevent stale files in `dist`; run build before tests.

<sup>Written for commit ae466dd36c91684bf52449343817cdd2f262b949. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

