### PR TITLE
fix: pass through upstream HTTP errors

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -142,8 +142,10 @@ This derivation ensures:
   - When the request has no payload body, the request MUST be sent without `Ehbp-Encapsulated-Key` and the response will be unencrypted. See Section 7.4 for the security rationale.
 - Inbound response:
 
-  - For requests with encrypted bodies: Require `Ehbp-Response-Nonce`; derive response keys using the procedure in Section 4.4 (using the retained HPKE sender context from the request). Stream-decrypt the chunked body using the derived AES-256-GCM key.
-  - If `Ehbp-Response-Nonce` is missing or invalid, the client MUST fail the request and MUST NOT treat the response body as authenticated application data. The client MAY parse plaintext error details only for diagnostics and recovery (Section 5.4), but this does not make the response trustworthy.
+  - For requests with encrypted bodies: Require `Ehbp-Response-Nonce` (subject to the error pass-through rule below); derive response keys using the procedure in Section 4.4 (using the retained HPKE sender context from the request). Stream-decrypt the chunked body using the derived AES-256-GCM key.
+  - If `Ehbp-Response-Nonce` is present, the client decrypts the response regardless of HTTP status code; servers encrypt error responses too whenever a receiver context was established (Section 5.2).
+  - If `Ehbp-Response-Nonce` is invalid, or absent on a response with a 2xx status code, the client MUST fail the request and MUST NOT treat the response body as authenticated application data. The client MAY parse plaintext error details only for diagnostics and recovery (Section 5.4), but this does not make the response trustworthy.
+  - If `Ehbp-Response-Nonce` is absent on a response with a non-2xx status code, the client MAY pass the response through to the caller unchanged as an unauthenticated plaintext error (see Section 5.3 for the trust implications). Any session recovery token for that exchange (Section 6) MUST be treated as consumed.
   - For bodyless requests: The response is unencrypted. Process as a normal HTTP response.
 
 ### 5.2 Server
@@ -171,7 +173,12 @@ The presence or absence of `Ehbp-Response-Nonce` in the response indicates wheth
 - `Ehbp-Response-Nonce` present → response body is encrypted
 - `Ehbp-Response-Nonce` absent → response body is plaintext
 
-Clients that send encrypted requests MUST verify `Ehbp-Response-Nonce` is present in the response. If the header is missing, the client MUST fail the request rather than falling back to reading plaintext. This prevents body substitution attacks where an attacker strips the nonce header and replaces the encrypted body with attacker-controlled plaintext.
+Clients that send encrypted requests MUST verify `Ehbp-Response-Nonce` is present before treating a response body as authenticated application data:
+
+- If the header is missing on a response with a 2xx status code, the client MUST fail the request rather than falling back to reading plaintext. This prevents body substitution attacks where an attacker strips the nonce header and replaces the encrypted body with attacker-controlled plaintext.
+- If the header is missing on a response with a non-2xx status code, the client MAY pass the response through to the caller unchanged. Such responses are typically produced by intermediaries (load balancers, CDNs, rate limiters) that reject or fail the request without it ever reaching the EHBP server. These bodies are unauthenticated: an on-path attacker can forge them, or strip the nonce header from a genuine encrypted error response and substitute arbitrary plaintext. Callers MUST treat pass-through error bodies as untrusted diagnostics and MUST NOT act on them as authenticated application data.
+
+The pass-through allowance applies only to non-2xx responses; exchanges that claim success always fail closed without a valid nonce.
 
 ### 5.4 Error Handling and Recovery
 
@@ -185,7 +192,7 @@ EHBP implementations MUST treat these as protocol failures:
 - HPKE setup/decapsulation failure
 - chunk framing violation
 - AEAD authentication/decryption failure
-- missing/invalid `Ehbp-Response-Nonce` when an encrypted response is expected
+- invalid `Ehbp-Response-Nonce`, or `Ehbp-Response-Nonce` missing from a 2xx response, when an encrypted response is expected (a missing nonce on a non-2xx response is handled per Section 5.3 and is not a protocol failure)
 
 Implementations MUST fail closed: no plaintext fallback for encrypted exchanges and no partial decrypted data exposure after authentication failure.
 

--- a/client/client.go
+++ b/client/client.go
@@ -238,6 +238,11 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			return nil, identity.NewKeyConfigError(fmt.Errorf("%s", title))
 		}
 
+		if resp.Header.Get(protocol.ResponseNonceHeader) == "" &&
+			(resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices) {
+			return resp, nil
+		}
+
 		if err := identity.DecryptResponseWithToken(resp, token); err != nil {
 			resp.Body.Close()
 			return nil, fmt.Errorf("failed to decrypt response: %v", err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -407,6 +407,67 @@ func TestTransportReturnsErrorOnKeyConfigMismatch(t *testing.T) {
 	assert.True(t, identity.IsKeyConfigError(err))
 }
 
+func TestTransportPassesThroughNonceLessErrorResponse(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Upstream-Error", "rate-limited")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"try again later"}`))
+	}))
+	defer server.Close()
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+
+	transport, err := NewTransportWithIdentity(pubIdentity)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest("POST", server.URL, bytes.NewBufferString("secret"))
+	assert.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "rate-limited", resp.Header.Get("X-Upstream-Error"))
+	assert.Equal(t, `{"error":"try again later"}`, string(body))
+	assert.Nil(t, transport.GetSessionRecoveryToken())
+}
+
+func TestTransportRejectsNonceLessSuccessResponse(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("plaintext"))
+	}))
+	defer server.Close()
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+
+	transport, err := NewTransportWithIdentity(pubIdentity)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest("POST", server.URL, bytes.NewBufferString("secret"))
+	assert.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	assert.Nil(t, resp)
+	assert.ErrorContains(t, err, protocol.ResponseNonceHeader)
+	assert.Nil(t, transport.GetSessionRecoveryToken())
+}
+
 func TestTransportGetSessionRecoveryToken(t *testing.T) {
 	serverIdentity, err := identity.NewIdentity()
 	assert.NoError(t, err)

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -81,6 +81,20 @@ export class Transport {
     }
   }
 
+  private static async shouldDecryptResponse(response: Response): Promise<boolean> {
+    if (response.headers.has(PROTOCOL.RESPONSE_NONCE_HEADER)) {
+      return true;
+    }
+
+    await Transport.checkKeyConfigMismatch(response);
+
+    if (!response.ok) {
+      return false;
+    }
+
+    throw new ProtocolError(`Missing ${PROTOCOL.RESPONSE_NONCE_HEADER} header`);
+  }
+
   /**
    * Get the server identity
    */
@@ -167,13 +181,9 @@ export class Transport {
       return response;
     }
 
-    // Throws KeyConfigMismatchError if server returned 422 key-config mismatch
-    await Transport.checkKeyConfigMismatch(response);
-
-    // Check for response nonce header (required for response decryption)
-    const responseNonceHeader = response.headers.get(PROTOCOL.RESPONSE_NONCE_HEADER);
-    if (!responseNonceHeader) {
-      throw new ProtocolError(`Missing ${PROTOCOL.RESPONSE_NONCE_HEADER} header`);
+    const shouldDecrypt = await Transport.shouldDecryptResponse(response);
+    if (!shouldDecrypt) {
+      return response;
     }
 
     // Publish token only after confirming the response is valid

--- a/js/src/test/client.test.ts
+++ b/js/src/test/client.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert';
-import { Identity, Transport, createTransport, KeyConfigMismatchError } from '../index.js';
+import {
+  Identity,
+  Transport,
+  createTransport,
+  KeyConfigMismatchError,
+  ProtocolError,
+} from '../index.js';
 import { PROTOCOL } from '../protocol.js';
 import { CipherSuite } from 'hpke';
 import { KEM_DHKEM_X25519_HKDF_SHA256, KDF_HKDF_SHA256, AEAD_AES_256_GCM } from '@panva/hpke-noble';
@@ -31,7 +37,11 @@ function toArrayBuffer(bytes: Uint8Array<ArrayBufferLike>): ArrayBuffer {
   return copy.buffer;
 }
 
-async function buildEncryptedResponse(request: Request, serverIdentity: Identity): Promise<Response> {
+async function buildEncryptedResponse(
+  request: Request,
+  serverIdentity: Identity,
+  status = 200
+): Promise<Response> {
   const requestEncHex = request.headers.get(PROTOCOL.ENCAPSULATED_KEY_HEADER);
   assert(requestEncHex, `Missing ${PROTOCOL.ENCAPSULATED_KEY_HEADER} header`);
   const requestEnc = hexToBytes(requestEncHex);
@@ -79,7 +89,7 @@ async function buildEncryptedResponse(request: Request, serverIdentity: Identity
   );
 
   return new Response(toArrayBuffer(encodeSingleChunk(responseCiphertext)), {
-    status: 200,
+    status,
     headers: {
       [PROTOCOL.RESPONSE_NONCE_HEADER]: bytesToHex(responseNonce),
     },
@@ -226,27 +236,57 @@ describe('Transport', () => {
     }
   });
 
-  it('should not throw KeyConfigMismatchError for 422 without problem+json', async () => {
+  it('should pass through nonce-less 4xx and 5xx responses', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+
+    const originalFetch = globalThis.fetch;
+    let responseStatus = 400;
+    let rawResponse!: Response;
+
+    globalThis.fetch = (async (): Promise<Response> => {
+      rawResponse = new Response(`upstream error ${responseStatus}`, {
+        status: responseStatus,
+        headers: { 'content-type': 'text/plain' },
+      });
+      return rawResponse;
+    }) as typeof fetch;
+
+    try {
+      for (const status of [400, 503]) {
+        responseStatus = status;
+        const response = await transport.post('https://server.test/secure', 'hello');
+
+        assert.strictEqual(response, rawResponse);
+        assert.strictEqual(response.status, status);
+        assert.strictEqual(response.headers.get('content-type'), 'text/plain');
+        assert.strictEqual(await response.text(), `upstream error ${status}`);
+        assert.throws(
+          () => transport.getSessionRecoveryToken(),
+          /No session recovery token available/
+        );
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should reject a nonce-less 2xx response', async () => {
     const serverIdentity = await Identity.generate();
     const transport = new Transport(serverIdentity, 'server.test');
 
     const originalFetch = globalThis.fetch;
 
     globalThis.fetch = (async (): Promise<Response> => {
-      // 422 without problem+json content type — not a key mismatch
-      return new Response('Unprocessable', {
-        status: 422,
-        headers: { 'content-type': 'text/plain' },
-      });
+      return new Response('plaintext success', { status: 200 });
     }) as typeof fetch;
 
     try {
-      // Should not throw KeyConfigMismatchError — but will throw ProtocolError
-      // because the response has no Ehbp-Response-Nonce header
       await assert.rejects(
         () => transport.post('https://server.test/secure', 'hello'),
         (err: unknown) => {
-          assert(!(err instanceof KeyConfigMismatchError), 'Should not be KeyConfigMismatchError');
+          assert(err instanceof ProtocolError);
+          assert.match(err.message, new RegExp(`Missing ${PROTOCOL.RESPONSE_NONCE_HEADER} header`));
           return true;
         }
       );
@@ -270,6 +310,26 @@ describe('Transport', () => {
       const response = await transport.post('https://server.test/secure', 'hello');
       const responseText = await response.text();
       assert.strictEqual(responseText, 'processed:hello');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should decrypt a response with a nonce regardless of HTTP status', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      const request = input instanceof Request ? input : new Request(input);
+      return buildEncryptedResponse(request, serverIdentity, 503);
+    }) as typeof fetch;
+
+    try {
+      const response = await transport.post('https://server.test/secure', 'hello');
+      assert.strictEqual(response.status, 503);
+      assert.strictEqual(await response.text(), 'processed:hello');
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/python/src/ehbp/_http.py
+++ b/python/src/ehbp/_http.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
+from typing import Optional
 
 import httpx
 
@@ -69,3 +70,9 @@ def response_nonce(headers: httpx.Headers) -> bytes:
             f"invalid response nonce length: expected {RESPONSE_NONCE_LENGTH}, got {len(nonce)}"
         )
     return nonce
+
+
+def response_nonce_for_status(status: int, headers: httpx.Headers) -> Optional[bytes]:
+    if RESPONSE_NONCE_HEADER not in headers and status // 100 != 2:
+        return None
+    return response_nonce(headers)

--- a/python/src/ehbp/client.py
+++ b/python/src/ehbp/client.py
@@ -1,10 +1,11 @@
 """Synchronous EHBP client transport built on httpx.
 
 The client encrypts request bodies to the server's HPKE public key and decrypts
-the bound response body. It fails closed on any missing/invalid response nonce
-and enforces several defensive constraints (single configured origin, no
-credentials in URLs, reserved protocol headers cannot be overridden, redirects
-disabled, response size capped).
+the bound response body. It passes through nonce-less non-success responses,
+fails closed on nonce-less successes or invalid nonces, and enforces several
+defensive constraints (single configured origin, no credentials in URLs,
+reserved protocol headers cannot be overridden, redirects disabled, response
+size capped).
 """
 
 from __future__ import annotations
@@ -26,7 +27,7 @@ from ._http import (
     raise_for_key_config_mismatch as _raise_for_key_config_mismatch,
 )
 from ._http import (
-    response_nonce as _response_nonce,
+    response_nonce_for_status as _response_nonce_for_status,
 )
 from ._http import (
     single_chunk_body as _single_chunk_body,
@@ -218,7 +219,10 @@ class Client:
                 response_headers = resp.headers
                 raw = self._read_body_capped(resp)
             _raise_for_key_config_mismatch(status, response_headers, raw)
-            response_nonce = _response_nonce(response_headers)
+            response_nonce = _response_nonce_for_status(status, response_headers)
+            if response_nonce is None:
+                self._clear_token_if_current(token)
+                return Response(status, response_headers, raw)
             decrypted = token.decrypt_response_body(response_nonce, raw)
         except BaseException:
             self._clear_token_if_current(token)
@@ -290,8 +294,13 @@ class Client:
                     raw = self._read_body_capped(resp)
                     self._clear_token_if_current(token)
                     _raise_for_key_config_mismatch(status, response_headers, raw)
-                    raise ProtocolError(f"missing {RESPONSE_NONCE_HEADER} header")
-                response_nonce = _response_nonce(response_headers)
+                    response_nonce = _response_nonce_for_status(status, response_headers)
+                    if response_nonce is None:
+                        yield StreamingResponse(status, response_headers, iter((raw,)))
+                        return
+                else:
+                    response_nonce = _response_nonce_for_status(status, response_headers)
+                assert response_nonce is not None
                 key_material = derive_response_keys(
                     token.exported_secret, token.request_enc, response_nonce
                 )

--- a/python/src/ehbp/transport.py
+++ b/python/src/ehbp/transport.py
@@ -22,7 +22,7 @@ import httpx
 from ._http import (
     DEFAULT_MAX_RESPONSE_BYTES,
     raise_for_key_config_mismatch,
-    response_nonce,
+    response_nonce_for_status,
     single_chunk_body,
 )
 from .derive import FrameDecryptor, derive_response_keys
@@ -76,6 +76,15 @@ def _decrypted_headers(response: httpx.Response) -> httpx.Headers:
     if "content-length" in headers:
         del headers["content-length"]
     return headers
+
+
+def _buffered_response(response: httpx.Response, body: bytes) -> httpx.Response:
+    return httpx.Response(
+        status_code=response.status_code,
+        headers=response.headers,
+        content=body,
+        extensions=response.extensions,
+    )
 
 
 def _make_decryptor(
@@ -175,9 +184,13 @@ class EHBPTransport(httpx.BaseTransport):
             finally:
                 response.close()
             raise_for_key_config_mismatch(response.status_code, response.headers, body)
-            raise ProtocolError(f"missing {RESPONSE_NONCE_HEADER} header")
+            nonce = response_nonce_for_status(response.status_code, response.headers)
+            if nonce is None:
+                return _buffered_response(response, body)
+        else:
+            nonce = response_nonce_for_status(response.status_code, response.headers)
 
-        nonce = response_nonce(response.headers)
+        assert nonce is not None
         decryptor = _make_decryptor(token, nonce, self._max_response_bytes)
         return httpx.Response(
             status_code=response.status_code,
@@ -245,9 +258,13 @@ class AsyncEHBPTransport(httpx.AsyncBaseTransport):
             finally:
                 await response.aclose()
             raise_for_key_config_mismatch(response.status_code, response.headers, body)
-            raise ProtocolError(f"missing {RESPONSE_NONCE_HEADER} header")
+            nonce = response_nonce_for_status(response.status_code, response.headers)
+            if nonce is None:
+                return _buffered_response(response, body)
+        else:
+            nonce = response_nonce_for_status(response.status_code, response.headers)
 
-        nonce = response_nonce(response.headers)
+        assert nonce is not None
         decryptor = _make_decryptor(token, nonce, self._max_response_bytes)
         return httpx.Response(
             status_code=response.status_code,

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -44,12 +44,15 @@ def _new_suite() -> CipherSuite:
 
 
 class MockServer:
-    def __init__(self, *, mode: str = "ok", chunk_size: Optional[int] = None) -> None:
+    def __init__(
+        self, *, mode: str = "ok", chunk_size: Optional[int] = None, status_code: int = 200
+    ) -> None:
         self.suite = _new_suite()
         self.keypair = self.suite.kem.derive_key_pair(b"ehbp-python-test-server-ikm-0001")
         self.public_key_bytes = self.keypair.public_key.to_public_bytes()
         self.mode = mode
         self.chunk_size = chunk_size
+        self.status_code = status_code
         self.last_request: Optional[httpx.Request] = None
 
     def config_bytes(self) -> bytes:
@@ -105,6 +108,13 @@ class MockServer:
         enc = bytes.fromhex(enc_hex)
         request_plaintext, exported = self._open_request(enc, body)
 
+        if self.mode == "unencrypted_response":
+            return httpx.Response(
+                self.status_code,
+                headers={"content-type": "text/plain", "x-upstream": "proxy"},
+                content=b"upstream unavailable",
+            )
+
         if self.mode == "key_config_mismatch":
             problem = {"type": KEY_CONFIG_PROBLEM_TYPE, "title": "stale key configuration"}
             return httpx.Response(
@@ -118,7 +128,7 @@ class MockServer:
         headers = {}
         if self.mode != "strip_nonce":
             headers[RESPONSE_NONCE_HEADER] = response_nonce.hex()
-        return httpx.Response(200, headers=headers, content=framed)
+        return httpx.Response(self.status_code, headers=headers, content=framed)
 
     def http_client(self) -> httpx.Client:
         return httpx.Client(
@@ -136,8 +146,10 @@ class MockServer:
 
 @pytest.fixture
 def make_server():
-    def _factory(*, mode: str = "ok", chunk_size: Optional[int] = None) -> MockServer:
-        return MockServer(mode=mode, chunk_size=chunk_size)
+    def _factory(
+        *, mode: str = "ok", chunk_size: Optional[int] = None, status_code: int = 200
+    ) -> MockServer:
+        return MockServer(mode=mode, chunk_size=chunk_size, status_code=status_code)
 
     return _factory
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -99,6 +99,37 @@ def test_missing_response_nonce_fails_closed(make_server):
     assert client.get_session_recovery_token() is None
 
 
+@pytest.mark.parametrize("status_code", [300, 400, 503])
+def test_unencrypted_non_success_response_passes_through(make_server, status_code):
+    server = make_server(mode="unencrypted_response", status_code=status_code)
+    client = server.make_client()
+    response = client.post("/v1/echo", body=b"payload")
+    assert response.status_code == status_code
+    assert response.headers["content-type"] == "text/plain"
+    assert response.headers["x-upstream"] == "proxy"
+    assert response.content == b"upstream unavailable"
+    assert client.get_session_recovery_token() is None
+
+
+def test_streaming_unencrypted_non_success_response_passes_through(make_server):
+    server = make_server(mode="unencrypted_response", status_code=429)
+    client = server.make_client()
+    with client.stream("POST", "/v1/echo", body=b"payload") as response:
+        assert response.status_code == 429
+        assert response.headers["content-type"] == "text/plain"
+        assert b"".join(response.iter_bytes()) == b"upstream unavailable"
+    assert client.get_session_recovery_token() is None
+
+
+def test_encrypted_non_success_response_is_decrypted(make_server):
+    server = make_server(status_code=503)
+    client = server.make_client()
+    response = client.post("/v1/echo", body=b"payload")
+    assert response.status_code == 503
+    assert response.content == b"echo:payload"
+    assert client.get_session_recovery_token() is not None
+
+
 def test_key_config_mismatch_raises_dedicated_error(make_server):
     server = make_server(mode="key_config_mismatch")
     client = server.make_client()

--- a/python/tests/test_transport.py
+++ b/python/tests/test_transport.py
@@ -85,6 +85,35 @@ def test_missing_response_nonce_fails_closed(make_server):
         client.post(URL, content=b"payload")
 
 
+@pytest.mark.parametrize("status_code", [300, 400, 503])
+def test_unencrypted_non_success_response_passes_through(make_server, status_code):
+    server = make_server(mode="unencrypted_response", status_code=status_code)
+    with _sync_client(server) as client:
+        response = client.post(URL, content=b"payload")
+    assert response.status_code == status_code
+    assert response.headers["content-type"] == "text/plain"
+    assert response.headers["x-upstream"] == "proxy"
+    assert response.content == b"upstream unavailable"
+
+
+def test_streaming_unencrypted_non_success_response_passes_through(make_server):
+    server = make_server(mode="unencrypted_response", status_code=429)
+    with _sync_client(server) as client, client.stream(
+        "POST", URL, content=b"payload"
+    ) as response:
+        assert response.status_code == 429
+        assert response.headers["content-type"] == "text/plain"
+        assert b"".join(response.iter_bytes()) == b"upstream unavailable"
+
+
+def test_encrypted_non_success_response_is_decrypted(make_server):
+    server = make_server(status_code=503)
+    with _sync_client(server) as client:
+        response = client.post(URL, content=b"payload")
+    assert response.status_code == 503
+    assert response.content == b"echo:payload"
+
+
 def test_oversized_response_chunk_is_rejected(server: MockServer):
     with _sync_client(server, max_response_bytes=4) as client, pytest.raises(ProtocolError):
         client.post(URL, content=b"this response will exceed the tiny cap")
@@ -138,6 +167,34 @@ def test_async_bodyless_request_passes_through(server: MockServer):
     response = asyncio.run(run())
     assert response.content == b"plaintext ok"
     assert ENCAPSULATED_KEY_HEADER not in server.last_request.headers
+
+
+def test_async_unencrypted_non_success_response_passes_through(make_server):
+    server = make_server(mode="unencrypted_response", status_code=503)
+
+    async def run() -> httpx.Response:
+        async with _async_client(server) as client:
+            return await client.post(URL, content=b"payload")
+
+    response = asyncio.run(run())
+    assert response.status_code == 503
+    assert response.headers["content-type"] == "text/plain"
+    assert response.headers["x-upstream"] == "proxy"
+    assert response.content == b"upstream unavailable"
+
+
+def test_async_streaming_unencrypted_non_success_response_passes_through(make_server):
+    server = make_server(mode="unencrypted_response", status_code=429)
+
+    async def run() -> bytes:
+        async with _async_client(server) as client, client.stream(
+            "POST", URL, content=b"payload"
+        ) as response:
+            assert response.status_code == 429
+            assert response.headers["content-type"] == "text/plain"
+            return b"".join([chunk async for chunk in response.aiter_bytes()])
+
+    assert asyncio.run(run()) == b"upstream unavailable"
 
 
 def test_async_key_config_mismatch_raises_dedicated_error(make_server):

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -285,11 +285,26 @@ impl Client {
         let mut headers = response.headers().clone();
 
         if !headers.contains_key(RESPONSE_NONCE_HEADER) {
-            let body = read_response_body_capped(response, DEFAULT_MAX_RESPONSE_BYTES).await?;
-            check_key_config_mismatch(status, &headers, &body)?;
-            return Err(Error::Protocol(format!(
-                "missing {RESPONSE_NONCE_HEADER} header"
-            )));
+            if status.is_success() {
+                return Err(Error::Protocol(format!(
+                    "missing {RESPONSE_NONCE_HEADER} header"
+                )));
+            }
+
+            let body = if is_problem_json_status(status, &headers) {
+                let body = read_response_body_capped(response, DEFAULT_MAX_RESPONSE_BYTES).await?;
+                check_key_config_mismatch(status, &headers, &body)?;
+                Box::pin(async_stream::stream! {
+                    yield Ok(body);
+                }) as Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>
+            } else {
+                Box::pin(response.bytes_stream().map_reqwest_error())
+            };
+            return Ok(OpenedEncryptedResponse {
+                status,
+                headers,
+                body,
+            });
         }
 
         let response_nonce = response_nonce(&headers)?;
@@ -352,7 +367,17 @@ impl Client {
             });
         };
 
-        check_key_config_mismatch(status, &headers, &body)?;
+        if !headers.contains_key(RESPONSE_NONCE_HEADER) {
+            check_key_config_mismatch(status, &headers, &body)?;
+            if !status.is_success() {
+                return Ok(Response {
+                    status,
+                    headers,
+                    body,
+                });
+            }
+        }
+
         let response_nonce = response_nonce(&headers)?;
         let decrypted = token.decrypt_response_body(&response_nonce, &body)?;
         self.clear_session_recovery_token_if_current(&token);
@@ -1020,6 +1045,132 @@ mod tests {
         assert!(client.get_session_recovery_token().is_none());
     }
 
+    async fn client_with_unencrypted_response(status: StatusCode) -> Client {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut bytes = Vec::new();
+            let mut buf = [0u8; 1024];
+            loop {
+                let n = socket.read(&mut buf).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                bytes.extend_from_slice(&buf[..n]);
+                if bytes.windows(5).any(|window| window == b"0\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let body = b"upstream unavailable";
+            let header = format!(
+                "HTTP/1.1 {} {}\r\nContent-Type: text/plain\r\nX-Upstream: proxy\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                status.as_u16(),
+                status.canonical_reason().unwrap(),
+                body.len(),
+            );
+            socket.write_all(header.as_bytes()).await.unwrap();
+            socket.write_all(body).await.unwrap();
+        });
+
+        let identity = ServerIdentity::from_public_key_bytes(&[7u8; 32]).unwrap();
+        Client::with_identity_and_http_client(
+            Url::parse(&format!("http://{addr}/")).unwrap(),
+            identity,
+            reqwest::Client::new(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn buffered_transport_passes_through_unencrypted_http_errors() {
+        let client = client_with_unencrypted_response(StatusCode::BAD_GATEWAY).await;
+
+        let response = client
+            .post("/secure")
+            .unwrap()
+            .body("secret")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(response.headers()[CONTENT_TYPE], "text/plain");
+        assert_eq!(response.headers()["x-upstream"], "proxy");
+        assert_eq!(response.text().unwrap(), "upstream unavailable");
+        assert!(client.get_session_recovery_token().is_none());
+    }
+
+    #[tokio::test]
+    async fn streaming_transport_passes_through_unencrypted_http_errors() {
+        let client = client_with_unencrypted_response(StatusCode::TOO_MANY_REQUESTS).await;
+
+        let response = client
+            .post("/secure")
+            .unwrap()
+            .body("secret")
+            .send_stream()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers()[CONTENT_TYPE], "text/plain");
+        assert_eq!(response.headers()["x-upstream"], "proxy");
+        assert!(client.get_session_recovery_token().is_none());
+        let body = response
+            .into_stream()
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()
+            .unwrap()
+            .concat();
+        assert_eq!(body, b"upstream unavailable");
+        assert!(client.get_session_recovery_token().is_none());
+    }
+
+    #[tokio::test]
+    async fn buffered_transport_rejects_unencrypted_successes() {
+        let client = client_with_unencrypted_response(StatusCode::OK).await;
+
+        let err = client
+            .post("/secure")
+            .unwrap()
+            .body("secret")
+            .send()
+            .await
+            .err()
+            .unwrap();
+
+        assert!(matches!(
+            err,
+            Error::Protocol(message) if message.contains(RESPONSE_NONCE_HEADER)
+        ));
+        assert!(client.get_session_recovery_token().is_none());
+    }
+
+    #[tokio::test]
+    async fn streaming_transport_rejects_unencrypted_successes() {
+        let client = client_with_unencrypted_response(StatusCode::OK).await;
+
+        let err = client
+            .post("/secure")
+            .unwrap()
+            .body("secret")
+            .send_stream()
+            .await
+            .err()
+            .unwrap();
+
+        assert!(matches!(
+            err,
+            Error::Protocol(message) if message.contains(RESPONSE_NONCE_HEADER)
+        ));
+        assert!(client.get_session_recovery_token().is_none());
+    }
+
     fn dummy_client() -> Client {
         let identity = ServerIdentity::from_public_key_bytes(&[7u8; 32]).unwrap();
         Client::with_identity_and_http_client(
@@ -1213,7 +1364,7 @@ mod tests {
         let body = crate::derive::frame_chunk(&ciphertext).unwrap();
         let url = Url::parse("https://example.com/v1/chat").unwrap();
         let response = http::Response::builder()
-            .status(StatusCode::OK)
+            .status(StatusCode::BAD_REQUEST)
             .url(url.clone())
             .header(CONTENT_TYPE, "text/plain")
             .header(CONTENT_LENGTH, body.len())
@@ -1229,7 +1380,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.url(), &url);
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         assert_eq!(response.extensions().get::<Marker>(), Some(&Marker(7)));
         assert_eq!(response.headers()[CONTENT_TYPE], "text/plain");
         assert!(response.headers().get(CONTENT_LENGTH).is_none());
@@ -1266,6 +1417,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn raw_transport_passes_through_unencrypted_http_errors() {
+        let (client, _) = raw_client_with_private_key();
+        let request = reqwest::Client::new()
+            .post("https://example.com/v1/chat")
+            .body("secret")
+            .build()
+            .unwrap();
+        let prepared = client.prepare_raw_request(request).await.unwrap();
+        let url = Url::parse("https://example.com/v1/chat").unwrap();
+        let response = http::Response::builder()
+            .status(StatusCode::SERVICE_UNAVAILABLE)
+            .url(url.clone())
+            .header(CONTENT_TYPE, "text/plain")
+            .header("x-upstream", "proxy")
+            .body(reqwest::Body::from("upstream unavailable"))
+            .unwrap();
+
+        let response = client
+            .open_raw_response(reqwest::Response::from(response), prepared.token)
+            .await
+            .unwrap();
+
+        assert_eq!(response.url(), &url);
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers()[CONTENT_TYPE], "text/plain");
+        assert_eq!(response.headers()["x-upstream"], "proxy");
+        assert_eq!(
+            response.bytes().await.unwrap(),
+            Bytes::from_static(b"upstream unavailable")
+        );
+        assert!(client.get_session_recovery_token().is_none());
+    }
+
+    #[tokio::test]
     async fn older_raw_response_error_preserves_newer_recovery_token() {
         let (client, _) = raw_client_with_private_key();
         let build_request = || {
@@ -1286,15 +1471,12 @@ mod tests {
                 .unwrap(),
         );
 
-        let err = client
+        let response = client
             .open_raw_response(response, Some(first_token))
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert!(matches!(
-            err,
-            Error::Protocol(message) if message.contains("missing")
-        ));
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
         assert_eq!(
             client.get_session_recovery_token().as_ref(),
             Some(&second_token)

--- a/swift/Sources/EHBP/Client.swift
+++ b/swift/Sources/EHBP/Client.swift
@@ -52,7 +52,8 @@ public final class EHBPClient: @unchecked Sendable {
     ///   - path: URL path (will be appended to baseURL)
     ///   - headers: Additional headers to include
     ///   - body: Request body (will be encrypted)
-    /// - Returns: Decrypted response data
+    /// - Returns: Decrypted response data, or an untouched non-success response
+    ///   when an intermediary returns an unencrypted error
     public func request(
         method: String,
         path: String,
@@ -96,12 +97,11 @@ public final class EHBPClient: @unchecked Sendable {
             throw EHBPError.networkError("expected HTTP response")
         }
 
-        guard requestContext != nil else {
+        guard let responseNonceHex = try EHBPClient.responseNonceHex(
+            from: httpResponse,
+            requestWasEncrypted: requestContext != nil
+        ) else {
             return (data, httpResponse)
-        }
-
-        guard let responseNonceHex = httpResponse.value(forHTTPHeaderField: EHBPProtocol.responseNonceHeader) else {
-            throw EHBPError.missingHeader(EHBPProtocol.responseNonceHeader)
         }
 
         guard let responseNonce = Data(hexString: responseNonceHex) else {
@@ -132,7 +132,8 @@ public final class EHBPClient: @unchecked Sendable {
     ///   - path: URL path
     ///   - headers: Additional headers
     ///   - body: Request body (will be encrypted)
-    /// - Returns: AsyncThrowingStream of decrypted response chunks
+    /// - Returns: AsyncThrowingStream of decrypted response chunks, or untouched
+    ///   non-success response chunks when an intermediary returns an unencrypted error
     public func requestStream(
         method: String,
         path: String,
@@ -176,7 +177,10 @@ public final class EHBPClient: @unchecked Sendable {
             throw EHBPError.networkError("expected HTTP response")
         }
 
-        guard requestContext != nil else {
+        guard let responseNonceHex = try EHBPClient.responseNonceHex(
+            from: httpResponse,
+            requestWasEncrypted: requestContext != nil
+        ) else {
             let stream = AsyncThrowingStream<Data, Error> { continuation in
                 Task {
                     do {
@@ -194,10 +198,6 @@ public final class EHBPClient: @unchecked Sendable {
                 }
             }
             return (stream, httpResponse)
-        }
-
-        guard let responseNonceHex = httpResponse.value(forHTTPHeaderField: EHBPProtocol.responseNonceHeader) else {
-            throw EHBPError.missingHeader(EHBPProtocol.responseNonceHeader)
         }
 
         guard let responseNonce = Data(hexString: responseNonceHex) else {
@@ -264,6 +264,20 @@ public final class EHBPClient: @unchecked Sendable {
         }
 
         return (stream, EHBPClient.sanitizedResponse(httpResponse))
+    }
+
+    private static func responseNonceHex(
+        from response: HTTPURLResponse,
+        requestWasEncrypted: Bool
+    ) throws -> String? {
+        guard requestWasEncrypted else { return nil }
+        if let nonce = response.value(forHTTPHeaderField: EHBPProtocol.responseNonceHeader) {
+            return nonce
+        }
+        guard !(200..<300).contains(response.statusCode) else {
+            throw EHBPError.missingHeader(EHBPProtocol.responseNonceHeader)
+        }
+        return nil
     }
 
     /// Removes framing headers that describe the encrypted body. The

--- a/swift/Tests/EHBPTests/UnencryptedResponseTests.swift
+++ b/swift/Tests/EHBPTests/UnencryptedResponseTests.swift
@@ -1,0 +1,97 @@
+import Crypto
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import XCTest
+@testable import EHBP
+
+final class UnencryptedResponseTests: XCTestCase {
+    private func makeClient(statusCode: Int) throws -> EHBPClient {
+        let serverPrivateKey = Curve25519.KeyAgreement.PrivateKey()
+        UnencryptedResponseURLProtocol.statusCode = statusCode
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [UnencryptedResponseURLProtocol.self]
+        return try EHBPClient(
+            baseURL: "https://server.test",
+            publicKey: Data(serverPrivateKey.publicKey.rawRepresentation),
+            session: URLSession(configuration: configuration)
+        )
+    }
+
+    override func tearDown() {
+        UnencryptedResponseURLProtocol.statusCode = 500
+        super.tearDown()
+    }
+
+    func testRequestPassesThroughUnencryptedNonSuccessResponses() async throws {
+        for statusCode in [300, 400, 503] {
+            let client = try makeClient(statusCode: statusCode)
+            let (data, response) = try await client.request(
+                method: "POST",
+                path: "/secure",
+                body: Data("hello".utf8)
+            )
+
+            XCTAssertEqual(response.statusCode, statusCode)
+            XCTAssertEqual(response.value(forHTTPHeaderField: "Content-Type"), "text/plain")
+            XCTAssertEqual(data, Data("upstream unavailable".utf8))
+            XCTAssertThrowsError(try client.getSessionRecoveryToken())
+        }
+    }
+
+    func testStreamingRequestPassesThroughUnencryptedNonSuccessResponse() async throws {
+        let client = try makeClient(statusCode: 429)
+        let (stream, response) = try await client.requestStream(
+            method: "POST",
+            path: "/secure",
+            body: Data("hello".utf8)
+        )
+        var data = Data()
+        for try await chunk in stream {
+            data.append(chunk)
+        }
+
+        XCTAssertEqual(response.statusCode, 429)
+        XCTAssertEqual(response.value(forHTTPHeaderField: "Content-Type"), "text/plain")
+        XCTAssertEqual(data, Data("upstream unavailable".utf8))
+        XCTAssertThrowsError(try client.getSessionRecoveryToken())
+    }
+
+    func testSuccessfulUnencryptedResponseRemainsRejected() async throws {
+        let client = try makeClient(statusCode: 200)
+
+        do {
+            _ = try await client.request(
+                method: "POST",
+                path: "/secure",
+                body: Data("hello".utf8)
+            )
+            XCTFail("Expected a missing response nonce error")
+        } catch EHBPError.missingHeader(let header) {
+            XCTAssertEqual(header, EHBPProtocol.responseNonceHeader)
+        }
+    }
+}
+
+private final class UnencryptedResponseURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var statusCode = 500
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/plain"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("upstream unavailable".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Passes through unencrypted non-2xx HTTP responses from intermediaries, preserving status, headers, and body instead of throwing missing-header errors. Applies to regular and streaming requests across all clients; SPEC updated to allow this.

- **Bug Fixes**
  - request()/requestStream(): if `Ehbp-Response-Nonce` is missing and status is non-2xx, return the raw response unchanged and do not publish a session recovery token.
  - Reject nonce-less 2xx; decrypt when a nonce is present regardless of status.
  - SPEC clarifies pass-through semantics and trust; tests cover 300/400/429/503 and streaming paths.

<sup>Written for commit 0a9228c3858f2955aa2d32cb6d244fec445fad21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

