### PR TITLE
Feat: add incremental stream recovery to all clients

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -259,6 +259,32 @@ To decrypt a response using a session recovery token:
 2. Derive response keys using the procedure in Section 4.4, substituting the token's `exported_secret` for the HPKE export and the token's `request_enc` for `enc`.
 3. Decrypt the response body using the derived AES-256-GCM key and the chunked framing in Section 4.3.
 
+### 6.2.1 Incremental Recovery, Replay, and Tailing
+
+Recovery decryption MAY be performed incrementally as encrypted response bytes
+arrive. An incremental decryptor:
+
+- MUST use the original `Ehbp-Response-Nonce` associated with the response.
+- MUST begin the frame sequence number at zero and increment it only after
+  successfully authenticating a non-empty frame.
+- MUST buffer incomplete framing and MUST emit a frame's plaintext only after
+  that complete frame has been authenticated.
+- MUST reject an end-of-stream that leaves a partial length prefix or partial
+  encrypted frame.
+
+Authenticated emission establishes only that the emitted frames are valid
+prefixes of the response. Application-level completion (for example an SSE
+terminal event or a complete JSON document) MUST be established separately;
+transport EOF alone does not prove that the application response is complete.
+
+If recovery reconnects to a server that replays and then tails the response,
+the encrypted response MUST be replayed from the first frame and the client
+MUST restart decryption at sequence number zero with the original response
+nonce. EHBP does not support resuming from an arbitrary ciphertext or plaintext
+byte offset. A client MAY suppress already-delivered application data after
+authenticating the replayed frames, but it MUST still process those frames from
+sequence number zero.
+
 ### 6.3 Security Considerations for Tokens
 
 - A session recovery token is equivalent in power to the ability to decrypt a single response. It MUST be treated as sensitive key material.

--- a/identity/crypt.go
+++ b/identity/crypt.go
@@ -446,6 +446,8 @@ func (ctx *RequestContext) DecryptResponse(resp *http.Response) error {
 const maxResponseChunkBytes = 64 << 20
 
 // DerivedStreamingDecryptReader decrypts response chunks using derived keys.
+// It emits each plaintext chunk as soon as the complete encrypted frame has
+// been authenticated and rejects truncated framing at end-of-stream.
 type DerivedStreamingDecryptReader struct {
 	reader io.Reader
 	aead   *ResponseAEAD
@@ -466,45 +468,48 @@ func (r *DerivedStreamingDecryptReader) Read(p []byte) (n int, err error) {
 		return n, nil
 	}
 
-	// Read chunk length (4 bytes)
-	chunkLenBytes := make([]byte, 4)
-	_, err = io.ReadFull(r.reader, chunkLenBytes)
-	if err != nil {
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
-			r.eof = true
-			return 0, io.EOF
+	for {
+		// Read chunk length (4 bytes)
+		chunkLenBytes := make([]byte, 4)
+		var bytesRead int
+		bytesRead, err = io.ReadFull(r.reader, chunkLenBytes)
+		if err != nil {
+			if err == io.EOF && bytesRead == 0 {
+				r.eof = true
+				return 0, io.EOF
+			}
+			return 0, fmt.Errorf("failed to read chunk length: %w", err)
 		}
-		return 0, fmt.Errorf("failed to read chunk length: %w", err)
-	}
 
-	chunkLen := binary.BigEndian.Uint32(chunkLenBytes)
-	if chunkLen == 0 {
-		return r.Read(p) // Skip empty chunks
-	}
-	if chunkLen > maxResponseChunkBytes {
-		return 0, fmt.Errorf("encrypted response chunk exceeds maximum allowed size")
-	}
+		chunkLen := binary.BigEndian.Uint32(chunkLenBytes)
+		if chunkLen == 0 {
+			continue
+		}
+		if chunkLen > maxResponseChunkBytes {
+			return 0, fmt.Errorf("encrypted response chunk exceeds maximum allowed size")
+		}
 
-	// Read encrypted chunk
-	encryptedChunk := make([]byte, chunkLen)
-	_, err = io.ReadFull(r.reader, encryptedChunk)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read encrypted chunk: %w", err)
-	}
+		// Read encrypted chunk
+		encryptedChunk := make([]byte, chunkLen)
+		_, err = io.ReadFull(r.reader, encryptedChunk)
+		if err != nil {
+			return 0, fmt.Errorf("failed to read encrypted chunk: %w", err)
+		}
 
-	// Decrypt chunk (nonce is computed and sequence incremented automatically)
-	decryptedChunk, err := r.aead.Open(encryptedChunk, nil)
-	if err != nil {
-		return 0, fmt.Errorf("failed to decrypt chunk: %w", err)
-	}
+		// Decrypt chunk (nonce is computed and sequence incremented automatically)
+		decryptedChunk, err := r.aead.Open(encryptedChunk, nil)
+		if err != nil {
+			return 0, fmt.Errorf("failed to decrypt chunk: %w", err)
+		}
 
-	// Return as much as fits, buffer the rest
-	n = copy(p, decryptedChunk)
-	if n < len(decryptedChunk) {
-		r.buffer = decryptedChunk[n:]
-	}
+		// Return as much as fits, buffer the rest
+		n = copy(p, decryptedChunk)
+		if n < len(decryptedChunk) {
+			r.buffer = decryptedChunk[n:]
+		}
 
-	return n, nil
+		return n, nil
+	}
 }
 
 func (r *DerivedStreamingDecryptReader) Close() error {

--- a/identity/derive.go
+++ b/identity/derive.go
@@ -129,7 +129,11 @@ func (km *ResponseKeyMaterial) NewResponseAEAD() (*ResponseAEAD, error) {
 // Seal encrypts plaintext with the given additional authenticated data.
 // It automatically computes the nonce from the current sequence number
 // and increments the sequence for the next operation.
+// It panics if the sequence number is exhausted.
 func (r *ResponseAEAD) Seal(plaintext, aad []byte) []byte {
+	if r.seq == ^uint64(0) {
+		panic("response chunk sequence overflow")
+	}
 	nonce := r.computeNonce()
 	r.seq++
 	return r.aead.Seal(nil, nonce, plaintext, aad)

--- a/identity/derive.go
+++ b/identity/derive.go
@@ -140,6 +140,9 @@ func (r *ResponseAEAD) Seal(plaintext, aad []byte) []byte {
 // and increments the sequence for the next operation.
 // Returns an error if authentication fails.
 func (r *ResponseAEAD) Open(ciphertext, aad []byte) ([]byte, error) {
+	if r.seq == ^uint64(0) {
+		return nil, fmt.Errorf("response chunk sequence overflow")
+	}
 	nonce := r.computeNonce()
 	r.seq++
 	return r.aead.Open(nil, nonce, ciphertext, aad)

--- a/identity/derive_test.go
+++ b/identity/derive_test.go
@@ -338,6 +338,25 @@ func TestMultipleChunksRoundTrip(t *testing.T) {
 	}
 }
 
+func TestResponseAEADSealRejectsSequenceOverflow(t *testing.T) {
+	km := &ResponseKeyMaterial{
+		Key:       make([]byte, AES256KeyLength),
+		NonceBase: make([]byte, AESGCMNonceLength),
+	}
+	aead, err := km.NewResponseAEAD()
+	if err != nil {
+		t.Fatalf("NewResponseAEAD failed: %v", err)
+	}
+	aead.seq = ^uint64(0)
+
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("Seal should panic when the response sequence is exhausted")
+		}
+	}()
+	aead.Seal([]byte("data"), nil)
+}
+
 func TestWrongSequenceNumberFails(t *testing.T) {
 	exportedSecret := make([]byte, 32)
 	requestEnc := make([]byte, 32)

--- a/identity/session_recovery.go
+++ b/identity/session_recovery.go
@@ -67,8 +67,10 @@ func ExtractSessionRecoveryToken(ctx *RequestContext) (*SessionRecoveryToken, er
 	}, nil
 }
 
-// DecryptResponseWithToken decrypts an HTTP response using only a
-// SessionRecoveryToken (no live HPKE context required).
+// DecryptResponseWithToken replaces an HTTP response body with an incremental
+// authenticated plaintext stream using only a SessionRecoveryToken (no live
+// HPKE context required). Plaintext frames become readable before the encrypted
+// body reaches EOF. Closing the replacement body closes the original body.
 func DecryptResponseWithToken(resp *http.Response, token *SessionRecoveryToken) error {
 	if token == nil {
 		return fmt.Errorf("session recovery token is nil")

--- a/identity/session_recovery_test.go
+++ b/identity/session_recovery_test.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -16,6 +17,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tinfoilsh/encrypted-http-body-protocol/protocol"
 )
+
+type closeTrackingBody struct {
+	io.Reader
+	closed chan struct{}
+}
+
+func (b *closeTrackingBody) Close() error {
+	close(b.closed)
+	return nil
+}
 
 func TestSessionRecoveryTokenFields(t *testing.T) {
 	serverIdentity, err := NewIdentity()
@@ -218,6 +229,130 @@ func TestDecryptResponseWithTokenMultiChunk(t *testing.T) {
 	decrypted, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, "chunk1chunk2chunk3", string(decrypted))
+}
+
+func TestDecryptResponseWithTokenDeliversBeforeSourceEOF(t *testing.T) {
+	serverIdentity, err := NewIdentity()
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/test", strings.NewReader("request"))
+	reqCtx, err := serverIdentity.EncryptRequestWithContext(req)
+	require.NoError(t, err)
+	token, err := ExtractSessionRecoveryToken(reqCtx)
+	require.NoError(t, err)
+
+	respCtx, err := serverIdentity.DecryptRequestWithContext(req)
+	require.NoError(t, err)
+	_, err = io.ReadAll(req.Body)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	writer, err := serverIdentity.SetupDerivedResponseEncryption(recorder, respCtx)
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("first"))
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("second"))
+	require.NoError(t, err)
+	writer.Flush()
+
+	encrypted := recorder.Body.Bytes()
+	firstFrameLength := 4 + int(binary.BigEndian.Uint32(encrypted[:4]))
+	sourceReader, sourceWriter := io.Pipe()
+	releaseTail := make(chan struct{})
+	writeResult := make(chan error, 1)
+	go func() {
+		if _, writeErr := sourceWriter.Write(encrypted[:firstFrameLength]); writeErr != nil {
+			writeResult <- writeErr
+			return
+		}
+		<-releaseTail
+		_, writeErr := sourceWriter.Write(encrypted[firstFrameLength:])
+		closeErr := sourceWriter.CloseWithError(writeErr)
+		if writeErr == nil {
+			writeErr = closeErr
+		}
+		writeResult <- writeErr
+	}()
+
+	resp := &http.Response{
+		Header: recorder.Header(),
+		Body:   sourceReader,
+	}
+	require.NoError(t, DecryptResponseWithToken(resp, token))
+
+	first := make([]byte, len("first"))
+	_, err = io.ReadFull(resp.Body, first)
+	require.NoError(t, err)
+	assert.Equal(t, "first", string(first))
+
+	close(releaseTail)
+	tail, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "second", string(tail))
+	require.NoError(t, <-writeResult)
+}
+
+func TestDecryptResponseWithTokenRejectsTruncatedLengthPrefix(t *testing.T) {
+	token := &SessionRecoveryToken{
+		ExportedSecret: make([]byte, ExportLength),
+		RequestEnc:     make([]byte, ExportLength),
+	}
+	resp := &http.Response{
+		Header: make(http.Header),
+		Body:   io.NopCloser(bytes.NewReader([]byte{0, 0, 0})),
+	}
+	resp.Header.Set(protocol.ResponseNonceHeader, hex.EncodeToString(make([]byte, ResponseNonceLength)))
+
+	require.NoError(t, DecryptResponseWithToken(resp, token))
+	_, err := io.ReadAll(resp.Body)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "chunk length")
+}
+
+func TestDecryptResponseWithTokenCloseCancelsSource(t *testing.T) {
+	source := &closeTrackingBody{
+		Reader: strings.NewReader(""),
+		closed: make(chan struct{}),
+	}
+	token := &SessionRecoveryToken{
+		ExportedSecret: make([]byte, ExportLength),
+		RequestEnc:     make([]byte, ExportLength),
+	}
+	resp := &http.Response{
+		Header: make(http.Header),
+		Body:   source,
+	}
+	resp.Header.Set(protocol.ResponseNonceHeader, hex.EncodeToString(make([]byte, ResponseNonceLength)))
+
+	require.NoError(t, DecryptResponseWithToken(resp, token))
+	require.NoError(t, resp.Body.Close())
+
+	select {
+	case <-source.closed:
+	default:
+		t.Fatal("closing decrypted response body did not close encrypted source")
+	}
+}
+
+func TestDerivedStreamingDecryptReaderRejectsSequenceOverflow(t *testing.T) {
+	keyMaterial := &ResponseKeyMaterial{
+		Key:       make([]byte, AES256KeyLength),
+		NonceBase: make([]byte, AESGCMNonceLength),
+	}
+	aead, err := keyMaterial.NewResponseAEAD()
+	require.NoError(t, err)
+	aead.seq = ^uint64(0)
+
+	frame := make([]byte, 4+aead.Overhead())
+	binary.BigEndian.PutUint32(frame[:4], uint32(aead.Overhead()))
+	reader := &DerivedStreamingDecryptReader{
+		reader: bytes.NewReader(frame),
+		aead:   aead,
+	}
+
+	_, err = io.ReadAll(reader)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sequence overflow")
 }
 
 func TestDecryptResponseWithTokenEquivalentToContextPath(t *testing.T) {

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ehbp",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ehbp",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@panva/hpke-noble": "^1.0.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ehbp",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "JavaScript client for Encrypted HTTP Body Protocol (EHBP)",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/js/src/identity.ts
+++ b/js/src/identity.ts
@@ -362,6 +362,10 @@ export function deserializeSessionRecoveryToken(json: string): SessionRecoveryTo
 
 /**
  * Decrypt a response using a SessionRecoveryToken.
+ *
+ * The returned Response exposes an incremental authenticated plaintext stream:
+ * each complete frame is available before the encrypted response reaches EOF.
+ * Cancelling the returned body cancels the encrypted source body.
  */
 export async function decryptResponseWithToken(
   response: Response,
@@ -452,7 +456,11 @@ function createDecryptStream(
 
         const { done, value } = await reader.read();
         if (done) {
-          controller.close();
+          if (buffer.length !== 0) {
+            fail(new ProtocolError('truncated encrypted response chunk'));
+          } else {
+            controller.close();
+          }
           return;
         }
 

--- a/js/src/test/derive.test.ts
+++ b/js/src/test/derive.test.ts
@@ -106,6 +106,14 @@ describe('computeNonce', () => {
     const nonce = computeNonce(nonceBase, 0xFFFFFFFF);
     assert.strictEqual(nonce.length, 12);
   });
+
+  it('should reject sequence number overflow', () => {
+    const nonceBase = new Uint8Array(12).fill(0);
+    assert.throws(
+      () => computeNonce(nonceBase, 0x100000000),
+      /sequence number must be an integer in range/,
+    );
+  });
 });
 
 describe('encrypt/decrypt round trip', () => {

--- a/js/src/test/session-recovery.test.ts
+++ b/js/src/test/session-recovery.test.ts
@@ -324,6 +324,144 @@ describe('Session Recovery Token', () => {
       assert.strictEqual(text, chunks.join(''));
     });
 
+    it('should deliver an authenticated frame before source EOF', async () => {
+      const { identity, privateKey } = await generateTestKeys();
+      const request = new Request('https://server.test/api', {
+        method: 'POST',
+        body: 'hello',
+      });
+      const { request: encryptedRequest, context } =
+        await identity.encryptRequestWithContext(request);
+      assert(context);
+
+      const token = await extractSessionRecoveryToken(context);
+      const bufferedResponse = await buildStreamingEncryptedResponse(
+        encryptedRequest,
+        privateKey,
+        ['first', 'second'],
+      );
+      const nonce = bufferedResponse.headers.get(PROTOCOL.RESPONSE_NONCE_HEADER)!;
+      const encrypted = new Uint8Array(await bufferedResponse.arrayBuffer());
+      const firstFrameLength =
+        4 + new DataView(encrypted.buffer, encrypted.byteOffset, 4).getUint32(0, false);
+      let sourceController!: ReadableStreamDefaultController<Uint8Array>;
+      const source = new ReadableStream<Uint8Array>({
+        start(controller) {
+          sourceController = controller;
+          controller.enqueue(encrypted.slice(0, firstFrameLength));
+        },
+      });
+
+      const decrypted = await decryptResponseWithToken(
+        new Response(source, {
+          headers: { [PROTOCOL.RESPONSE_NONCE_HEADER]: nonce },
+        }),
+        token,
+      );
+      const reader = decrypted.body!.getReader();
+      const first = await reader.read();
+
+      assert.strictEqual(first.done, false);
+      assert.strictEqual(new TextDecoder().decode(first.value), 'first');
+
+      sourceController.enqueue(encrypted.slice(firstFrameLength));
+      sourceController.close();
+      const second = await reader.read();
+      assert.strictEqual(new TextDecoder().decode(second.value), 'second');
+      assert.strictEqual((await reader.read()).done, true);
+    });
+
+    it('should handle fragmented, coalesced, and zero-length frames', async () => {
+      const { identity, privateKey } = await generateTestKeys();
+      const request = new Request('https://server.test/api', {
+        method: 'POST',
+        body: 'hello',
+      });
+      const { request: encryptedRequest, context } =
+        await identity.encryptRequestWithContext(request);
+      assert(context);
+
+      const token = await extractSessionRecoveryToken(context);
+      const bufferedResponse = await buildStreamingEncryptedResponse(
+        encryptedRequest,
+        privateKey,
+        ['one', 'two', 'three'],
+      );
+      const nonce = bufferedResponse.headers.get(PROTOCOL.RESPONSE_NONCE_HEADER)!;
+      const encrypted = new Uint8Array(await bufferedResponse.arrayBuffer());
+      const framed = new Uint8Array(encrypted.length + 8);
+      framed.set(new Uint8Array(4), 0);
+      framed.set(encrypted, 4);
+      framed.set(new Uint8Array(4), 4 + encrypted.length);
+      const source = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(framed.slice(0, 1));
+          controller.enqueue(framed.slice(1, 7));
+          controller.enqueue(framed.slice(7));
+          controller.close();
+        },
+      });
+
+      const decrypted = await decryptResponseWithToken(
+        new Response(source, {
+          headers: { [PROTOCOL.RESPONSE_NONCE_HEADER]: nonce },
+        }),
+        token,
+      );
+
+      assert.strictEqual(await decrypted.text(), 'onetwothree');
+    });
+
+    it('should reject truncated framing at source EOF', async () => {
+      const { identity, privateKey } = await generateTestKeys();
+      const request = new Request('https://server.test/api', {
+        method: 'POST',
+        body: 'hello',
+      });
+      const { request: encryptedRequest, context } =
+        await identity.encryptRequestWithContext(request);
+      assert(context);
+
+      const token = await extractSessionRecoveryToken(context);
+      const bufferedResponse = await buildEncryptedResponse(
+        encryptedRequest,
+        privateKey,
+        'truncated',
+      );
+      const nonce = bufferedResponse.headers.get(PROTOCOL.RESPONSE_NONCE_HEADER)!;
+      const encrypted = new Uint8Array(await bufferedResponse.arrayBuffer());
+      const truncated = new Response(toArrayBuffer(encrypted.slice(0, -1)), {
+        headers: { [PROTOCOL.RESPONSE_NONCE_HEADER]: nonce },
+      });
+
+      const decrypted = await decryptResponseWithToken(truncated, token);
+      await assert.rejects(() => decrypted.text(), /truncated encrypted response chunk/);
+    });
+
+    it('should cancel the encrypted source when the decrypted body is cancelled', async () => {
+      const token: SessionRecoveryToken = {
+        exportedSecret: new Uint8Array(32),
+        requestEnc: new Uint8Array(32),
+      };
+      let sourceCancelled = false;
+      const source = new ReadableStream<Uint8Array>({
+        cancel() {
+          sourceCancelled = true;
+        },
+      });
+      const response = new Response(source, {
+        headers: {
+          [PROTOCOL.RESPONSE_NONCE_HEADER]:
+            bytesToHex(new Uint8Array(RESPONSE_NONCE_LENGTH)),
+        },
+      });
+
+      const decrypted = await decryptResponseWithToken(response, token);
+      await decrypted.body!.cancel('consumer stopped');
+
+      assert.strictEqual(sourceCancelled, true);
+    });
+
     it('should preserve response status and headers', async () => {
       const { identity, privateKey } = await generateTestKeys();
       const request = new Request('https://server.test/api', {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tinfoil-ehbp"
-version = "0.2.6"
+version = "0.3.0"
 description = "Python client for the encrypted HTTP body protocol"
 license = "MIT"
 requires-python = ">=3.9"

--- a/python/src/ehbp/__init__.py
+++ b/python/src/ehbp/__init__.py
@@ -3,6 +3,7 @@
 from . import protocol
 from .client import Client, Response, StreamingResponse
 from .derive import (
+    FrameDecryptor,
     ResponseKeyMaterial,
     compute_nonce,
     decrypt_chunk,
@@ -34,6 +35,7 @@ __all__ = [
     "ServerIdentity",
     "EncryptedRequest",
     "SessionRecoveryToken",
+    "FrameDecryptor",
     "ResponseKeyMaterial",
     "derive_response_keys",
     "compute_nonce",

--- a/python/src/ehbp/__init__.py
+++ b/python/src/ehbp/__init__.py
@@ -24,7 +24,7 @@ from .identity import EncryptedRequest, ServerIdentity
 from .session import SessionRecoveryToken
 from .transport import AsyncEHBPTransport, EHBPTransport
 
-__version__ = "0.2.6"
+__version__ = "0.3.0"
 
 __all__ = [
     "Client",

--- a/python/src/ehbp/client.py
+++ b/python/src/ehbp/client.py
@@ -32,7 +32,6 @@ from ._http import (
 from ._http import (
     single_chunk_body as _single_chunk_body,
 )
-from .derive import FrameDecryptor, derive_response_keys
 from .errors import InvalidInputError, ProtocolError
 from .identity import ServerIdentity
 from .protocol import (
@@ -301,22 +300,21 @@ class Client:
                 else:
                     response_nonce = _response_nonce_for_status(status, response_headers)
                 assert response_nonce is not None
-                key_material = derive_response_keys(
-                    token.exported_secret, token.request_enc, response_nonce
-                )
                 yield StreamingResponse(
                     status,
                     response_headers,
-                    self._decrypt_stream(resp, token, key_material),
+                    self._decrypt_stream(resp, token, response_nonce),
                 )
         except BaseException:
             self._clear_token_if_current(token)
             raise
 
     def _decrypt_stream(
-        self, resp: httpx.Response, token: SessionRecoveryToken, key_material: Any
+        self, resp: httpx.Response, token: SessionRecoveryToken, response_nonce: bytes
     ) -> Iterator[bytes]:
-        decryptor = FrameDecryptor(key_material, self._max_response_bytes)
+        decryptor = token.create_response_decryptor(
+            response_nonce, max_chunk_length=self._max_response_bytes
+        )
         try:
             for chunk in resp.iter_bytes():
                 yield from decryptor.push(chunk)

--- a/python/src/ehbp/derive.py
+++ b/python/src/ehbp/derive.py
@@ -117,29 +117,10 @@ def frame_chunk(ciphertext: bytes) -> bytes:
 
 
 def decrypt_framed_response(km: ResponseKeyMaterial, body: bytes) -> bytes:
-    out = bytearray()
-    offset = 0
-    seq = 0
-    total = len(body)
-
-    while offset < total:
-        if total - offset < LENGTH_PREFIX_SIZE:
-            raise ProtocolError("truncated chunk length")
-        chunk_len = struct.unpack_from(">I", body, offset)[0]
-        offset += LENGTH_PREFIX_SIZE
-
-        if chunk_len == 0:
-            continue
-        if total - offset < chunk_len:
-            raise ProtocolError("truncated encrypted chunk")
-
-        out += decrypt_chunk(km, seq, body[offset : offset + chunk_len])
-        if seq >= MAX_SEQUENCE:
-            raise ProtocolError("response chunk sequence overflow")
-        seq += 1
-        offset += chunk_len
-
-    return bytes(out)
+    decryptor = FrameDecryptor(km)
+    chunks = decryptor.push(body)
+    decryptor.finish()
+    return b"".join(chunks)
 
 
 class FrameDecryptor:

--- a/python/src/ehbp/session.py
+++ b/python/src/ehbp/session.py
@@ -11,9 +11,14 @@ import json
 from collections.abc import Mapping
 from typing import Any, Union
 
-from .derive import decrypt_framed_response, derive_response_keys
+from .derive import FrameDecryptor, decrypt_framed_response, derive_response_keys
 from .errors import InvalidInputError, ProtocolError
-from .protocol import EXPORT_LENGTH, REQUEST_ENC_LENGTH, RESPONSE_NONCE_LENGTH
+from .protocol import (
+    EXPORT_LENGTH,
+    MAX_CHUNK_LENGTH,
+    REQUEST_ENC_LENGTH,
+    RESPONSE_NONCE_LENGTH,
+)
 
 _EXPORTED_SECRET_KEY = "exportedSecret"
 _REQUEST_ENC_KEY = "requestEnc"
@@ -85,6 +90,7 @@ class SessionRecoveryToken:
         return cls.from_dict(decoded)
 
     def decrypt_response_body(self, response_nonce: bytes, body: bytes) -> bytes:
+        """Decrypt a complete framed response body."""
         if len(response_nonce) != RESPONSE_NONCE_LENGTH:
             raise ProtocolError(
                 f"response nonce must be {RESPONSE_NONCE_LENGTH} bytes, got {len(response_nonce)}"
@@ -93,3 +99,24 @@ class SessionRecoveryToken:
             self._exported_secret, self._request_enc, response_nonce
         )
         return decrypt_framed_response(key_material, body)
+
+    def create_response_decryptor(
+        self,
+        response_nonce: bytes,
+        *,
+        max_chunk_length: int = MAX_CHUNK_LENGTH,
+    ) -> FrameDecryptor:
+        """Create an incremental authenticated decryptor for this response.
+
+        Feed encrypted network bytes to :meth:`FrameDecryptor.push` and call
+        :meth:`FrameDecryptor.finish` at source EOF. Each returned plaintext
+        chunk has been authenticated and may be consumed before source EOF.
+        """
+        if len(response_nonce) != RESPONSE_NONCE_LENGTH:
+            raise ProtocolError(
+                f"response nonce must be {RESPONSE_NONCE_LENGTH} bytes, got {len(response_nonce)}"
+            )
+        key_material = derive_response_keys(
+            self._exported_secret, self._request_enc, response_nonce
+        )
+        return FrameDecryptor(key_material, max_chunk_length=max_chunk_length)

--- a/python/tests/test_derive.py
+++ b/python/tests/test_derive.py
@@ -2,10 +2,10 @@
 
 import pytest
 
-from ehbp import ResponseKeyMaterial, SessionRecoveryToken, compute_nonce
-from ehbp.derive import FrameDecryptor, decrypt_framed_response, encrypt_chunk, frame_chunk
-from ehbp.errors import ProtocolError
-from ehbp.protocol import AES_GCM_NONCE_LENGTH
+from ehbp import FrameDecryptor, ResponseKeyMaterial, SessionRecoveryToken, compute_nonce
+from ehbp.derive import decrypt_framed_response, derive_response_keys, encrypt_chunk, frame_chunk
+from ehbp.errors import CryptoError, ProtocolError
+from ehbp.protocol import AES_GCM_NONCE_LENGTH, MAX_SEQUENCE, RESPONSE_NONCE_LENGTH
 
 
 def test_nonce_uses_big_endian_sequence_xor():
@@ -81,3 +81,73 @@ def test_streaming_decryptor_rejects_oversized_chunk_length():
     oversized_prefix = (1 << 20).to_bytes(4, "big")
     with pytest.raises(ProtocolError):
         decryptor.push(oversized_prefix)
+
+
+def test_token_decryptor_delivers_before_source_eof():
+    exported_secret = bytes(range(32))
+    request_enc = bytes(reversed(range(32)))
+    response_nonce = bytes([7]) * RESPONSE_NONCE_LENGTH
+    token = SessionRecoveryToken(exported_secret, request_enc)
+    km = derive_response_keys(exported_secret, request_enc, response_nonce)
+    first = frame_chunk(encrypt_chunk(km, 0, b"first"))
+    second = frame_chunk(encrypt_chunk(km, 1, b"second"))
+
+    decryptor = token.create_response_decryptor(response_nonce)
+
+    assert decryptor.push(first) == [b"first"]
+    assert decryptor.push(second) == [b"second"]
+    decryptor.finish()
+
+
+def test_token_decryptor_handles_coalesced_and_zero_length_frames():
+    exported_secret = bytes(range(32))
+    request_enc = bytes(reversed(range(32)))
+    response_nonce = bytes([9]) * RESPONSE_NONCE_LENGTH
+    token = SessionRecoveryToken(exported_secret, request_enc)
+    km = derive_response_keys(exported_secret, request_enc, response_nonce)
+    framed = (
+        b"\x00\x00\x00\x00"
+        + frame_chunk(encrypt_chunk(km, 0, b"one"))
+        + frame_chunk(encrypt_chunk(km, 1, b"two"))
+        + b"\x00\x00\x00\x00"
+    )
+
+    decryptor = token.create_response_decryptor(response_nonce)
+
+    assert decryptor.push(framed) == [b"one", b"two"]
+    decryptor.finish()
+
+
+def test_token_decryptor_rejects_authentication_failure_before_emitting():
+    exported_secret = bytes(range(32))
+    request_enc = bytes(reversed(range(32)))
+    response_nonce = bytes([11]) * RESPONSE_NONCE_LENGTH
+    token = SessionRecoveryToken(exported_secret, request_enc)
+    km = derive_response_keys(exported_secret, request_enc, response_nonce)
+    framed = bytearray(frame_chunk(encrypt_chunk(km, 0, b"secret")))
+    framed[-1] ^= 1
+
+    decryptor = token.create_response_decryptor(response_nonce)
+
+    with pytest.raises(CryptoError):
+        decryptor.push(bytes(framed))
+
+
+def test_streaming_decryptor_rejects_truncated_eof():
+    km = _key_material()
+    framed = frame_chunk(encrypt_chunk(km, 0, b"data"))
+    decryptor = FrameDecryptor(km)
+
+    assert decryptor.push(framed[:-1]) == []
+    with pytest.raises(ProtocolError):
+        decryptor.finish()
+
+
+def test_streaming_decryptor_rejects_sequence_overflow():
+    km = _key_material()
+    framed = frame_chunk(encrypt_chunk(km, MAX_SEQUENCE, b"last"))
+    decryptor = FrameDecryptor(km)
+    decryptor._seq = MAX_SEQUENCE
+
+    with pytest.raises(ProtocolError, match="sequence overflow"):
+        decryptor.push(framed)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "tinfoil-ehbp"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "async-stream",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinfoil-ehbp"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.87"
 description = "Rust client for the encrypted HTTP body protocol"

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -868,7 +868,8 @@ fn decrypt_response_stream(
 
         while let Some(chunk) = poll_next(&mut stream).await {
             let chunk = chunk?;
-            for plaintext in decryptor.push(&chunk)? {
+            decryptor.feed(&chunk);
+            while let Some(plaintext) = decryptor.next_frame()? {
                 yield Bytes::from(plaintext);
             }
         }
@@ -1004,6 +1005,48 @@ mod tests {
 
         drop(decrypted);
         assert!(source_dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn streaming_decryption_yields_before_processing_later_frames() {
+        use aes_gcm::{
+            aead::{Aead as _, KeyInit as _, Payload},
+            Aes256Gcm, Nonce,
+        };
+
+        let vector: ResponseVector =
+            serde_json::from_str(include_str!("../../test-vectors/response-decryption.json"))
+                .unwrap();
+        let key_material = derive_response_keys(
+            &hex::decode(vector.exported_secret).unwrap(),
+            &hex::decode(vector.request_enc).unwrap(),
+            &hex::decode(vector.response_nonce).unwrap(),
+        )
+        .unwrap();
+        let cipher = Aes256Gcm::new_from_slice(&key_material.key).unwrap();
+        let nonce = crate::derive::compute_nonce(&key_material.nonce_base, 1);
+        let mut second = cipher
+            .encrypt(
+                Nonce::from_slice(&nonce),
+                Payload {
+                    msg: b"second",
+                    aad: &[],
+                },
+            )
+            .unwrap();
+        *second.last_mut().unwrap() ^= 1;
+
+        let mut coalesced = hex::decode(vector.encrypted_response).unwrap();
+        coalesced.extend_from_slice(&crate::derive::frame_chunk(&second).unwrap());
+        let source = stream::iter([Ok::<Bytes, reqwest::Error>(Bytes::from(coalesced))]);
+        let mut decrypted = Box::pin(decrypt_response_stream(source, key_material));
+
+        let first = decrypted.next().await.unwrap().unwrap();
+        assert_eq!(hex::encode(first), vector.plaintext);
+        assert!(matches!(
+            decrypted.next().await.unwrap(),
+            Err(Error::Crypto(_))
+        ));
     }
 
     #[tokio::test]

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut};
 use futures_core::Stream;
 #[cfg(not(target_arch = "wasm32"))]
 use http_body_util::BodyExt;
@@ -18,7 +18,7 @@ use std::{
 };
 
 use crate::{
-    derive::{decrypt_chunk, derive_response_keys},
+    derive::{derive_response_keys, ResponseDecryptor},
     identity::ServerIdentity,
     protocol::{
         ENCAPSULATED_KEY_HEADER, KEYS_MEDIA_TYPE, KEYS_PATH, KEY_CONFIG_PROBLEM_TYPE,
@@ -864,53 +864,16 @@ fn decrypt_response_stream(
     key_material: crate::derive::ResponseKeyMaterial,
 ) -> impl Stream<Item = Result<Bytes>> + Send {
     async_stream::try_stream! {
-        let mut buffer = BytesMut::new();
-        let mut seq = 0u64;
+        let mut decryptor = ResponseDecryptor::from_key_material(key_material);
 
         while let Some(chunk) = poll_next(&mut stream).await {
             let chunk = chunk?;
-            buffer.extend_from_slice(&chunk);
-
-            loop {
-                if buffer.len() < 4 {
-                    break;
-                }
-
-                let chunk_len = u32::from_be_bytes([
-                    buffer[0],
-                    buffer[1],
-                    buffer[2],
-                    buffer[3],
-                ]) as usize;
-
-                if chunk_len == 0 {
-                    buffer.advance(4);
-                    continue;
-                }
-
-                if chunk_len > DEFAULT_MAX_RESPONSE_BYTES {
-                    Err(Error::Protocol(
-                        "response chunk exceeds maximum allowed size".into(),
-                    ))?;
-                }
-
-                if buffer.len() < 4 + chunk_len {
-                    break;
-                }
-
-                buffer.advance(4);
-                let ciphertext = buffer.split_to(chunk_len).freeze();
-                let plaintext = decrypt_chunk(&key_material, seq, &ciphertext)?;
-                seq = seq
-                    .checked_add(1)
-                    .ok_or_else(|| Error::Protocol("response chunk sequence overflow".into()))?;
+            for plaintext in decryptor.push(&chunk)? {
                 yield Bytes::from(plaintext);
             }
         }
 
-        if !buffer.is_empty() {
-            Err(Error::Protocol("truncated encrypted response chunk".into()))?;
-        }
+        decryptor.finish()?;
     }
 }
 
@@ -944,7 +907,10 @@ mod tests {
     use super::*;
     use futures_util::{stream, StreamExt};
     use serde::Deserialize;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    };
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
@@ -958,6 +924,28 @@ mod tests {
         response_nonce: String,
         plaintext: String,
         encrypted_response: String,
+    }
+
+    struct DropTrackedResponseStream {
+        first: Option<Bytes>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl Stream for DropTrackedResponseStream {
+        type Item = reqwest::Result<Bytes>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            match self.first.take() {
+                Some(chunk) => Poll::Ready(Some(Ok(chunk))),
+                None => Poll::Pending,
+            }
+        }
+    }
+
+    impl Drop for DropTrackedResponseStream {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::SeqCst);
+        }
     }
 
     #[tokio::test]
@@ -986,6 +974,36 @@ mod tests {
         }
 
         assert_eq!(hex::encode(plaintext), vector.plaintext);
+    }
+
+    #[tokio::test]
+    async fn streaming_decryption_delivers_before_eof_and_cancels_source() {
+        let vector: ResponseVector =
+            serde_json::from_str(include_str!("../../test-vectors/response-decryption.json"))
+                .unwrap();
+        let key_material = derive_response_keys(
+            &hex::decode(vector.exported_secret).unwrap(),
+            &hex::decode(vector.request_enc).unwrap(),
+            &hex::decode(vector.response_nonce).unwrap(),
+        )
+        .unwrap();
+        let source_dropped = Arc::new(AtomicBool::new(false));
+        let source = DropTrackedResponseStream {
+            first: Some(Bytes::from(hex::decode(vector.encrypted_response).unwrap())),
+            dropped: Arc::clone(&source_dropped),
+        };
+        let mut decrypted = Box::pin(decrypt_response_stream(source, key_material));
+
+        let plaintext = decrypted
+            .next()
+            .await
+            .expect("first frame should be delivered without source EOF")
+            .unwrap();
+        assert_eq!(hex::encode(plaintext), vector.plaintext);
+        assert!(!source_dropped.load(Ordering::SeqCst));
+
+        drop(decrypted);
+        assert!(source_dropped.load(Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/rust/src/derive.rs
+++ b/rust/src/derive.rs
@@ -143,12 +143,24 @@ impl ResponseDecryptor {
 
     /// Adds encrypted bytes and returns all newly authenticated plaintext frames.
     pub fn push(&mut self, data: &[u8]) -> Result<Vec<Vec<u8>>> {
-        self.buffer.extend_from_slice(data);
+        self.feed(data);
         let mut plaintext = Vec::new();
 
+        while let Some(frame) = self.next_frame()? {
+            plaintext.push(frame);
+        }
+
+        Ok(plaintext)
+    }
+
+    pub(crate) fn feed(&mut self, data: &[u8]) {
+        self.buffer.extend_from_slice(data);
+    }
+
+    pub(crate) fn next_frame(&mut self) -> Result<Option<Vec<u8>>> {
         loop {
             if self.buffer.len() < 4 {
-                break;
+                return Ok(None);
             }
 
             let chunk_len = u32::from_be_bytes([
@@ -168,20 +180,22 @@ impl ResponseDecryptor {
                 ));
             }
             if self.buffer.len() < 4 + chunk_len {
-                break;
+                return Ok(None);
             }
             if self.sequence == u64::MAX {
                 return Err(Error::Protocol("response chunk sequence overflow".into()));
             }
 
-            self.buffer.advance(4);
-            let ciphertext = self.buffer.split_to(chunk_len).freeze();
-            let opened = decrypt_chunk(&self.key_material, self.sequence, &ciphertext)?;
+            let frame_len = 4 + chunk_len;
+            let opened = decrypt_chunk(
+                &self.key_material,
+                self.sequence,
+                &self.buffer[4..frame_len],
+            )?;
+            self.buffer.advance(frame_len);
             self.sequence += 1;
-            plaintext.push(opened);
+            return Ok(Some(opened));
         }
-
-        Ok(plaintext)
     }
 
     /// Validates that source EOF occurred on a frame boundary.
@@ -284,6 +298,8 @@ mod tests {
             tampered.push(&tampered_frame),
             Err(Error::Crypto(_))
         ));
+        assert_eq!(tampered.sequence, 0);
+        assert_eq!(&tampered.buffer[..], tampered_frame);
     }
 
     #[test]

--- a/rust/src/derive.rs
+++ b/rust/src/derive.rs
@@ -2,6 +2,7 @@ use aes_gcm::{
     aead::{Aead, KeyInit, Payload},
     Aes256Gcm, Nonce,
 };
+use bytes::{Buf, BytesMut};
 use hkdf::Hkdf;
 use sha2::Sha256;
 use std::fmt;
@@ -14,6 +15,8 @@ use crate::{
     },
     Error, Result,
 };
+
+const DEFAULT_MAX_RESPONSE_CHUNK_BYTES: usize = 64 * 1024 * 1024;
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct ResponseKeyMaterial {
@@ -110,39 +113,85 @@ pub(crate) fn decrypt_framed_response(
     key_material: &ResponseKeyMaterial,
     body: &[u8],
 ) -> Result<Vec<u8>> {
-    let mut out = Vec::new();
-    let mut offset = 0usize;
-    let mut seq = 0u64;
+    let mut decryptor = ResponseDecryptor::from_key_material(key_material.clone());
+    let out = decryptor.push(body)?.concat();
+    decryptor.finish()?;
+    Ok(out)
+}
 
-    while offset < body.len() {
-        if body.len() - offset < 4 {
-            return Err(Error::Protocol("truncated chunk length".into()));
+/// Incrementally decrypts an EHBP framed response.
+///
+/// Feed encrypted network bytes with [`Self::push`] and call [`Self::finish`]
+/// when the source reaches EOF. `push` returns each authenticated plaintext
+/// frame as soon as it is complete, without waiting for source EOF.
+pub struct ResponseDecryptor {
+    key_material: ResponseKeyMaterial,
+    buffer: BytesMut,
+    sequence: u64,
+    max_chunk_length: usize,
+}
+
+impl ResponseDecryptor {
+    pub(crate) fn from_key_material(key_material: ResponseKeyMaterial) -> Self {
+        Self {
+            key_material,
+            buffer: BytesMut::new(),
+            sequence: 0,
+            max_chunk_length: DEFAULT_MAX_RESPONSE_CHUNK_BYTES,
         }
-
-        let chunk_len = u32::from_be_bytes([
-            body[offset],
-            body[offset + 1],
-            body[offset + 2],
-            body[offset + 3],
-        ]) as usize;
-        offset += 4;
-
-        if chunk_len == 0 {
-            continue;
-        }
-        if body.len() - offset < chunk_len {
-            return Err(Error::Protocol("truncated encrypted chunk".into()));
-        }
-
-        let plaintext = decrypt_chunk(key_material, seq, &body[offset..offset + chunk_len])?;
-        out.extend_from_slice(&plaintext);
-        seq = seq
-            .checked_add(1)
-            .ok_or_else(|| Error::Protocol("response chunk sequence overflow".into()))?;
-        offset += chunk_len;
     }
 
-    Ok(out)
+    /// Adds encrypted bytes and returns all newly authenticated plaintext frames.
+    pub fn push(&mut self, data: &[u8]) -> Result<Vec<Vec<u8>>> {
+        self.buffer.extend_from_slice(data);
+        let mut plaintext = Vec::new();
+
+        loop {
+            if self.buffer.len() < 4 {
+                break;
+            }
+
+            let chunk_len = u32::from_be_bytes([
+                self.buffer[0],
+                self.buffer[1],
+                self.buffer[2],
+                self.buffer[3],
+            ]) as usize;
+
+            if chunk_len == 0 {
+                self.buffer.advance(4);
+                continue;
+            }
+            if chunk_len > self.max_chunk_length {
+                return Err(Error::Protocol(
+                    "response chunk exceeds maximum allowed size".into(),
+                ));
+            }
+            if self.buffer.len() < 4 + chunk_len {
+                break;
+            }
+            if self.sequence == u64::MAX {
+                return Err(Error::Protocol("response chunk sequence overflow".into()));
+            }
+
+            self.buffer.advance(4);
+            let ciphertext = self.buffer.split_to(chunk_len).freeze();
+            let opened = decrypt_chunk(&self.key_material, self.sequence, &ciphertext)?;
+            self.sequence += 1;
+            plaintext.push(opened);
+        }
+
+        Ok(plaintext)
+    }
+
+    /// Validates that source EOF occurred on a frame boundary.
+    pub fn finish(&self) -> Result<()> {
+        if self.buffer.is_empty() {
+            Ok(())
+        } else {
+            Err(Error::Protocol("truncated encrypted response chunk".into()))
+        }
+    }
 }
 
 pub(crate) fn frame_chunk(ciphertext: &[u8]) -> Result<Vec<u8>> {
@@ -157,6 +206,28 @@ pub(crate) fn frame_chunk(ciphertext: &[u8]) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn key_material() -> ResponseKeyMaterial {
+        ResponseKeyMaterial {
+            key: [7; AES256_KEY_LENGTH],
+            nonce_base: [9; AES_GCM_NONCE_LENGTH],
+        }
+    }
+
+    fn encrypted_frame(key_material: &ResponseKeyMaterial, seq: u64, plaintext: &[u8]) -> Vec<u8> {
+        let cipher = Aes256Gcm::new_from_slice(&key_material.key).unwrap();
+        let nonce = compute_nonce(&key_material.nonce_base, seq);
+        let ciphertext = cipher
+            .encrypt(
+                Nonce::from_slice(&nonce),
+                Payload {
+                    msg: plaintext,
+                    aad: &[],
+                },
+            )
+            .unwrap();
+        frame_chunk(&ciphertext).unwrap()
+    }
 
     #[test]
     fn nonce_uses_big_endian_sequence_xor() {
@@ -176,5 +247,60 @@ mod tests {
         assert!(debug.contains("[redacted]"));
         assert!(!debug.contains("1, 1"));
         assert!(!debug.contains("2, 2"));
+    }
+
+    #[test]
+    fn response_decryptor_delivers_before_finish_and_handles_fragmentation() {
+        let key_material = key_material();
+        let first = encrypted_frame(&key_material, 0, b"first");
+        let second = encrypted_frame(&key_material, 1, b"second");
+        let mut decryptor = ResponseDecryptor::from_key_material(key_material);
+
+        assert!(decryptor.push(&first[..3]).unwrap().is_empty());
+        assert_eq!(decryptor.push(&first[3..]).unwrap(), [b"first".to_vec()]);
+
+        let mut coalesced = vec![0, 0, 0, 0];
+        coalesced.extend_from_slice(&second);
+        coalesced.extend_from_slice(&[0, 0, 0, 0]);
+        assert_eq!(decryptor.push(&coalesced).unwrap(), [b"second".to_vec()]);
+        decryptor.finish().unwrap();
+    }
+
+    #[test]
+    fn response_decryptor_rejects_truncation_and_authentication_failure() {
+        let key_material = key_material();
+        let frame = encrypted_frame(&key_material, 0, b"secret");
+        let mut truncated = ResponseDecryptor::from_key_material(key_material.clone());
+        assert!(truncated
+            .push(&frame[..frame.len() - 1])
+            .unwrap()
+            .is_empty());
+        assert!(matches!(truncated.finish(), Err(Error::Protocol(_))));
+
+        let mut tampered_frame = frame;
+        *tampered_frame.last_mut().unwrap() ^= 1;
+        let mut tampered = ResponseDecryptor::from_key_material(key_material);
+        assert!(matches!(
+            tampered.push(&tampered_frame),
+            Err(Error::Crypto(_))
+        ));
+    }
+
+    #[test]
+    fn response_decryptor_enforces_size_and_sequence_limits() {
+        let mut oversized = ResponseDecryptor::from_key_material(key_material());
+        let oversized_prefix = u32::MAX.to_be_bytes();
+        assert!(matches!(
+            oversized.push(&oversized_prefix),
+            Err(Error::Protocol(message)) if message.contains("maximum allowed size")
+        ));
+
+        let mut exhausted = ResponseDecryptor::from_key_material(key_material());
+        exhausted.sequence = u64::MAX;
+        let frame = frame_chunk(&[0; 16]).unwrap();
+        assert!(matches!(
+            exhausted.push(&frame),
+            Err(Error::Protocol(message)) if message.contains("sequence overflow")
+        ));
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,7 +8,7 @@ mod protocol;
 mod session;
 
 pub use client::{Client, RequestBuilder, Response, StreamingResponse};
-pub use derive::{compute_nonce, derive_response_keys, ResponseKeyMaterial};
+pub use derive::{compute_nonce, derive_response_keys, ResponseDecryptor, ResponseKeyMaterial};
 pub use error::{Error, Result};
 pub use identity::ServerIdentity;
 pub use protocol::*;

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::{
-    derive::{decrypt_framed_response, derive_response_keys},
+    derive::{decrypt_framed_response, derive_response_keys, ResponseDecryptor},
     protocol::{EXPORT_LENGTH, REQUEST_ENC_LENGTH, RESPONSE_NONCE_LENGTH},
     Error, Result,
 };
@@ -71,6 +71,22 @@ impl SessionRecoveryToken {
         let key_material =
             derive_response_keys(&self.exported_secret, &self.request_enc, response_nonce)?;
         decrypt_framed_response(&key_material, body)
+    }
+
+    /// Creates an incremental authenticated decryptor for this response.
+    ///
+    /// The caller must feed the response from its first frame and call
+    /// [`ResponseDecryptor::finish`] when the encrypted source reaches EOF.
+    pub fn response_decryptor(&self, response_nonce: &[u8]) -> Result<ResponseDecryptor> {
+        if response_nonce.len() != RESPONSE_NONCE_LENGTH {
+            return Err(Error::Protocol(format!(
+                "response nonce must be {RESPONSE_NONCE_LENGTH} bytes, got {}",
+                response_nonce.len()
+            )));
+        }
+        let key_material =
+            derive_response_keys(&self.exported_secret, &self.request_enc, response_nonce)?;
+        Ok(ResponseDecryptor::from_key_material(key_material))
     }
 }
 

--- a/rust/tests/vectors.rs
+++ b/rust/tests/vectors.rs
@@ -71,6 +71,27 @@ fn decrypts_response_from_shared_vector() {
 }
 
 #[test]
+fn incrementally_decrypts_response_from_shared_vector() {
+    let vector: ResponseVector =
+        serde_json::from_str(include_str!("../../test-vectors/response-decryption.json")).unwrap();
+    let token = SessionRecoveryToken::new(
+        hex::decode(vector.exported_secret).unwrap(),
+        hex::decode(vector.request_enc).unwrap(),
+    )
+    .unwrap();
+    let encrypted = hex::decode(vector.encrypted_response).unwrap();
+    let mut decryptor = token
+        .response_decryptor(&hex::decode(vector.response_nonce).unwrap())
+        .unwrap();
+
+    assert!(decryptor.push(&encrypted[..3]).unwrap().is_empty());
+    let plaintext = decryptor.push(&encrypted[3..]).unwrap().concat();
+    decryptor.finish().unwrap();
+
+    assert_eq!(hex::encode(plaintext), vector.plaintext);
+}
+
+#[test]
 fn session_recovery_token_serializes_shared_json_shape() {
     let vector: TokenVector = serde_json::from_str(include_str!(
         "../../test-vectors/session-recovery-token.json"

--- a/swift/Sources/EHBP/Client.swift
+++ b/swift/Sources/EHBP/Client.swift
@@ -182,7 +182,7 @@ public final class EHBPClient: @unchecked Sendable {
             requestWasEncrypted: requestContext != nil
         ) else {
             let stream = AsyncThrowingStream<Data, Error> { continuation in
-                Task {
+                let task = Task {
                     do {
                         var buffer = Data()
                         for try await byte in asyncBytes {
@@ -196,6 +196,7 @@ public final class EHBPClient: @unchecked Sendable {
                         continuation.finish(throwing: error)
                     }
                 }
+                continuation.onTermination = { _ in task.cancel() }
             }
             return (stream, httpResponse)
         }
@@ -204,9 +205,7 @@ public final class EHBPClient: @unchecked Sendable {
             throw EHBPError.invalidResponse("invalid response nonce hex")
         }
 
-        let keyMaterial = try EHBP.deriveResponseKeys(
-            exportedSecret: token!.exportedSecret,
-            requestEnc: token!.requestEnc,
+        let responseDecryptor = try token!.makeResponseDecryptor(
             responseNonce: responseNonce
         )
 
@@ -215,52 +214,23 @@ public final class EHBPClient: @unchecked Sendable {
         tokenLock.unlock()
 
         let stream = AsyncThrowingStream<Data, Error> { continuation in
-            Task {
+            let task = Task {
                 do {
-                    var buffer = [UInt8]()
-                    var seq: UInt64 = 0
+                    var decryptor = responseDecryptor
 
                     for try await byte in asyncBytes {
-                        buffer.append(byte)
-
-                        while buffer.count >= 4 {
-                            let chunkLength = Int(buffer[0]) << 24 |
-                                              Int(buffer[1]) << 16 |
-                                              Int(buffer[2]) << 8 |
-                                              Int(buffer[3])
-
-                            if chunkLength == 0 {
-                                buffer.removeFirst(4)
-                                continue
-                            }
-
-                            if chunkLength > EHBPConstants.maxResponseChunkBytes {
-                                throw EHBPError.invalidResponse("response chunk exceeds maximum allowed size")
-                            }
-
-                            guard buffer.count >= 4 + chunkLength else {
-                                break
-                            }
-
-                            let ciphertext = Data(buffer[4..<(4 + chunkLength)])
-                            buffer.removeFirst(4 + chunkLength)
-
-                            let plaintext = try decryptChunk(
-                                keyMaterial: keyMaterial,
-                                seq: seq,
-                                ciphertext: ciphertext
-                            )
-                            seq += 1
-
+                        for plaintext in try decryptor.push(Data([byte])) {
                             continuation.yield(plaintext)
                         }
                     }
 
+                    try decryptor.finish()
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
                 }
             }
+            continuation.onTermination = { _ in task.cancel() }
         }
 
         return (stream, EHBPClient.sanitizedResponse(httpResponse))

--- a/swift/Sources/EHBP/Client.swift
+++ b/swift/Sources/EHBP/Client.swift
@@ -219,7 +219,7 @@ public final class EHBPClient: @unchecked Sendable {
                     var decryptor = responseDecryptor
 
                     for try await byte in asyncBytes {
-                        for plaintext in try decryptor.push(Data([byte])) {
+                        if let plaintext = try decryptor.push(byte) {
                             continuation.yield(plaintext)
                         }
                     }

--- a/swift/Sources/EHBP/Derive.swift
+++ b/swift/Sources/EHBP/Derive.swift
@@ -127,6 +127,7 @@ public struct ResponseDecryptor {
     private let keyMaterial: ResponseKeyMaterial
     private let maxChunkLength: Int
     private var buffer = [UInt8]()
+    private var readOffset = 0
     private var sequence: UInt64
 
     init(
@@ -153,45 +154,71 @@ public struct ResponseDecryptor {
     /// Adds encrypted bytes and returns all newly authenticated plaintext chunks.
     public mutating func push(_ data: Data) throws -> [Data] {
         buffer.append(contentsOf: data)
+        defer { compactReadBytes() }
         var plaintext = [Data]()
 
-        while buffer.count >= 4 {
-            let chunkLength = Int(buffer[0]) << 24 |
-                              Int(buffer[1]) << 16 |
-                              Int(buffer[2]) << 8 |
-                              Int(buffer[3])
-
-            if chunkLength == 0 {
-                buffer.removeFirst(4)
-                continue
-            }
-            if chunkLength > maxChunkLength {
-                throw EHBPError.invalidResponse("response chunk exceeds maximum allowed size")
-            }
-            guard buffer.count >= 4 + chunkLength else {
-                break
-            }
-            guard sequence < UInt64.max else {
-                throw EHBPError.invalidResponse("response chunk sequence overflow")
-            }
-
-            let ciphertext = Data(buffer[4..<(4 + chunkLength)])
-            buffer.removeFirst(4 + chunkLength)
-            let opened = try decryptChunk(
-                keyMaterial: keyMaterial,
-                seq: sequence,
-                ciphertext: ciphertext
-            )
-            sequence += 1
+        while let opened = try decryptNextChunk() {
             plaintext.append(opened)
         }
 
         return plaintext
     }
 
+    /// Adds one encrypted byte and returns a newly authenticated plaintext chunk, if available.
+    public mutating func push(_ byte: UInt8) throws -> Data? {
+        buffer.append(byte)
+        defer { compactReadBytes() }
+        return try decryptNextChunk()
+    }
+
+    private mutating func decryptNextChunk() throws -> Data? {
+        let prefixBytes = EHBPConstants.responseLengthPrefixBytes
+
+        while buffer.count - readOffset >= prefixBytes {
+            let chunkLength = Int(buffer[readOffset]) << 24 |
+                              Int(buffer[readOffset + 1]) << 16 |
+                              Int(buffer[readOffset + 2]) << 8 |
+                              Int(buffer[readOffset + 3])
+            let ciphertextStart = readOffset + prefixBytes
+
+            if chunkLength == 0 {
+                readOffset = ciphertextStart
+                continue
+            }
+            if chunkLength > maxChunkLength {
+                throw EHBPError.invalidResponse("response chunk exceeds maximum allowed size")
+            }
+            guard buffer.count - ciphertextStart >= chunkLength else {
+                return nil
+            }
+            guard sequence < UInt64.max else {
+                throw EHBPError.invalidResponse("response chunk sequence overflow")
+            }
+
+            let frameEnd = ciphertextStart + chunkLength
+            let ciphertext = Data(buffer[ciphertextStart..<frameEnd])
+            let opened = try decryptChunk(
+                keyMaterial: keyMaterial,
+                seq: sequence,
+                ciphertext: ciphertext
+            )
+            readOffset = frameEnd
+            sequence += 1
+            return opened
+        }
+
+        return nil
+    }
+
+    private mutating func compactReadBytes() {
+        guard readOffset > 0 else { return }
+        buffer.removeFirst(readOffset)
+        readOffset = 0
+    }
+
     /// Validates that source EOF occurred on a frame boundary.
     public func finish() throws {
-        guard buffer.isEmpty else {
+        guard buffer.count == readOffset else {
             throw EHBPError.invalidResponse("truncated encrypted response chunk")
         }
     }

--- a/swift/Sources/EHBP/Derive.swift
+++ b/swift/Sources/EHBP/Derive.swift
@@ -118,6 +118,85 @@ public func decryptChunk(
     return try AES.GCM.open(sealedBox, using: keyMaterial.key)
 }
 
+/// Incrementally decrypts an EHBP length-prefixed response stream.
+///
+/// Feed encrypted network bytes with ``push(_:)`` and call ``finish()`` when
+/// the source reaches EOF. Each returned chunk has been authenticated and can
+/// be consumed before the source reaches EOF.
+public struct ResponseDecryptor {
+    private let keyMaterial: ResponseKeyMaterial
+    private let maxChunkLength: Int
+    private var buffer = [UInt8]()
+    private var sequence: UInt64
+
+    init(
+        keyMaterial: ResponseKeyMaterial,
+        maxChunkLength: Int = EHBPConstants.maxResponseChunkBytes
+    ) {
+        self.init(
+            keyMaterial: keyMaterial,
+            maxChunkLength: maxChunkLength,
+            initialSequence: 0
+        )
+    }
+
+    init(
+        keyMaterial: ResponseKeyMaterial,
+        maxChunkLength: Int,
+        initialSequence: UInt64
+    ) {
+        self.keyMaterial = keyMaterial
+        self.maxChunkLength = maxChunkLength
+        self.sequence = initialSequence
+    }
+
+    /// Adds encrypted bytes and returns all newly authenticated plaintext chunks.
+    public mutating func push(_ data: Data) throws -> [Data] {
+        buffer.append(contentsOf: data)
+        var plaintext = [Data]()
+
+        while buffer.count >= 4 {
+            let chunkLength = Int(buffer[0]) << 24 |
+                              Int(buffer[1]) << 16 |
+                              Int(buffer[2]) << 8 |
+                              Int(buffer[3])
+
+            if chunkLength == 0 {
+                buffer.removeFirst(4)
+                continue
+            }
+            if chunkLength > maxChunkLength {
+                throw EHBPError.invalidResponse("response chunk exceeds maximum allowed size")
+            }
+            guard buffer.count >= 4 + chunkLength else {
+                break
+            }
+            guard sequence < UInt64.max else {
+                throw EHBPError.invalidResponse("response chunk sequence overflow")
+            }
+
+            let ciphertext = Data(buffer[4..<(4 + chunkLength)])
+            buffer.removeFirst(4 + chunkLength)
+            let opened = try decryptChunk(
+                keyMaterial: keyMaterial,
+                seq: sequence,
+                ciphertext: ciphertext
+            )
+            sequence += 1
+            plaintext.append(opened)
+        }
+
+        return plaintext
+    }
+
+    /// Validates that source EOF occurred on a frame boundary.
+    public func finish() throws {
+        guard buffer.isEmpty else {
+            throw EHBPError.invalidResponse("truncated encrypted response chunk")
+        }
+    }
+}
+
 /// EHBP errors
 public enum EHBPError: Error, LocalizedError {
     case invalidInput(String)

--- a/swift/Sources/EHBP/Identity.swift
+++ b/swift/Sources/EHBP/Identity.swift
@@ -61,6 +61,25 @@ public struct SessionRecoveryToken: Sendable, Codable {
         }
         self.requestEnc = requestEncData
     }
+
+    /// Creates an incremental authenticated decryptor for this response.
+    public func makeResponseDecryptor(
+        responseNonce: Data,
+        maxChunkLength: Int = EHBPConstants.maxResponseChunkBytes
+    ) throws -> ResponseDecryptor {
+        guard maxChunkLength > 0 else {
+            throw EHBPError.invalidInput("maximum chunk length must be positive")
+        }
+        let keyMaterial = try deriveResponseKeys(
+            exportedSecret: exportedSecret,
+            requestEnc: requestEnc,
+            responseNonce: responseNonce
+        )
+        return ResponseDecryptor(
+            keyMaterial: keyMaterial,
+            maxChunkLength: maxChunkLength
+        )
+    }
 }
 
 /// Extracts a session recovery token from an HPKE request context
@@ -83,44 +102,12 @@ public func decryptResponseBody(
     responseNonce: Data,
     encryptedData: Data
 ) throws -> Data {
-    let keyMaterial = try deriveResponseKeys(
-        exportedSecret: token.exportedSecret,
-        requestEnc: token.requestEnc,
-        responseNonce: responseNonce
-    )
-
+    var decryptor = try token.makeResponseDecryptor(responseNonce: responseNonce)
     var result = Data()
-    var offset = 0
-    var seq: UInt64 = 0
-
-    while offset + 4 <= encryptedData.count {
-        let chunkLength = Int(encryptedData[offset]) << 24 |
-                          Int(encryptedData[offset + 1]) << 16 |
-                          Int(encryptedData[offset + 2]) << 8 |
-                          Int(encryptedData[offset + 3])
-        offset += 4
-
-        if chunkLength == 0 {
-            continue
-        }
-
-        guard offset + chunkLength <= encryptedData.count else {
-            throw EHBPError.invalidResponse("incomplete chunk at offset \(offset)")
-        }
-
-        let ciphertext = encryptedData.subdata(in: offset..<(offset + chunkLength))
-        offset += chunkLength
-
-        let plaintext = try decryptChunk(
-            keyMaterial: keyMaterial,
-            seq: seq,
-            ciphertext: ciphertext
-        )
-        seq += 1
-
+    for plaintext in try decryptor.push(encryptedData) {
         result.append(plaintext)
     }
-
+    try decryptor.finish()
     return result
 }
 

--- a/swift/Sources/EHBP/Protocol.swift
+++ b/swift/Sources/EHBP/Protocol.swift
@@ -50,6 +50,9 @@ public enum EHBPConstants {
     /// X25519 encapsulated key length
     public static let requestEncLength = 32
 
+    /// Length of a framed response chunk's big-endian length prefix
+    public static let responseLengthPrefixBytes = 4
+
     /// Label for deriving response key
     public static let responseKeyLabel = "key"
 

--- a/swift/Tests/EHBPTests/StreamingTests.swift
+++ b/swift/Tests/EHBPTests/StreamingTests.swift
@@ -384,4 +384,110 @@ final class StreamingTests: XCTestCase {
             }
         }
     }
+
+    func testTokenDecryptorDeliversBeforeEOFAndHandlesFramingPatterns() throws {
+        let token = SessionRecoveryToken(
+            exportedSecret: Data(repeating: 0xAB, count: EHBPConstants.exportLength),
+            requestEnc: Data(repeating: 0xCD, count: EHBPConstants.requestEncLength)
+        )
+        let responseNonce = Data(
+            repeating: 0xEF,
+            count: EHBPConstants.responseNonceLength
+        )
+        let keyMaterial = try deriveResponseKeys(
+            exportedSecret: token.exportedSecret,
+            requestEnc: token.requestEnc,
+            responseNonce: responseNonce
+        )
+        let first = try framedChunk(
+            keyMaterial: keyMaterial,
+            sequence: 0,
+            plaintext: Data("first".utf8)
+        )
+        let second = try framedChunk(
+            keyMaterial: keyMaterial,
+            sequence: 1,
+            plaintext: Data("second".utf8)
+        )
+        var decryptor = try token.makeResponseDecryptor(responseNonce: responseNonce)
+
+        XCTAssertTrue(try decryptor.push(first.prefix(3)).isEmpty)
+        XCTAssertEqual(try decryptor.push(first.dropFirst(3)), [Data("first".utf8)])
+
+        var coalesced = Data(repeating: 0, count: 4)
+        coalesced.append(second)
+        coalesced.append(Data(repeating: 0, count: 4))
+        XCTAssertEqual(try decryptor.push(coalesced), [Data("second".utf8)])
+        try decryptor.finish()
+    }
+
+    func testTokenDecryptorRejectsTruncationAndAuthenticationFailure() throws {
+        let token = SessionRecoveryToken(
+            exportedSecret: Data(repeating: 0xAB, count: EHBPConstants.exportLength),
+            requestEnc: Data(repeating: 0xCD, count: EHBPConstants.requestEncLength)
+        )
+        let responseNonce = Data(
+            repeating: 0xEF,
+            count: EHBPConstants.responseNonceLength
+        )
+        let keyMaterial = try deriveResponseKeys(
+            exportedSecret: token.exportedSecret,
+            requestEnc: token.requestEnc,
+            responseNonce: responseNonce
+        )
+        let frame = try framedChunk(
+            keyMaterial: keyMaterial,
+            sequence: 0,
+            plaintext: Data("secret".utf8)
+        )
+        var truncated = try token.makeResponseDecryptor(responseNonce: responseNonce)
+
+        XCTAssertTrue(try truncated.push(frame.dropLast()).isEmpty)
+        XCTAssertThrowsError(try truncated.finish())
+
+        var tamperedFrame = frame
+        tamperedFrame[tamperedFrame.index(before: tamperedFrame.endIndex)] ^= 1
+        var tampered = try token.makeResponseDecryptor(responseNonce: responseNonce)
+        XCTAssertThrowsError(try tampered.push(tamperedFrame))
+    }
+
+    func testResponseDecryptorEnforcesSizeAndSequenceLimits() throws {
+        let keyMaterial = try deriveResponseKeys(
+            exportedSecret: Data(repeating: 0xAB, count: EHBPConstants.exportLength),
+            requestEnc: Data(repeating: 0xCD, count: EHBPConstants.requestEncLength),
+            responseNonce: Data(repeating: 0xEF, count: EHBPConstants.responseNonceLength)
+        )
+        var oversized = ResponseDecryptor(keyMaterial: keyMaterial, maxChunkLength: 16)
+        XCTAssertThrowsError(try oversized.push(Data([0, 0, 0, 17])))
+
+        var exhausted = ResponseDecryptor(
+            keyMaterial: keyMaterial,
+            maxChunkLength: EHBPConstants.maxResponseChunkBytes,
+            initialSequence: UInt64.max
+        )
+        var frame = Data([0, 0, 0, 16])
+        frame.append(Data(repeating: 0, count: 16))
+        XCTAssertThrowsError(try exhausted.push(frame)) { error in
+            guard case EHBPError.invalidResponse(let message) = error else {
+                return XCTFail("expected invalidResponse, got \(error)")
+            }
+            XCTAssertTrue(message.contains("sequence overflow"))
+        }
+    }
+
+    private func framedChunk(
+        keyMaterial: ResponseKeyMaterial,
+        sequence: UInt64,
+        plaintext: Data
+    ) throws -> Data {
+        let ciphertext = try encryptChunk(
+            keyMaterial: keyMaterial,
+            seq: sequence,
+            plaintext: plaintext
+        )
+        var length = UInt32(ciphertext.count).bigEndian
+        var frame = Data(bytes: &length, count: 4)
+        frame.append(ciphertext)
+        return frame
+    }
 }

--- a/swift/Tests/EHBPTests/StreamingTests.swift
+++ b/swift/Tests/EHBPTests/StreamingTests.swift
@@ -449,6 +449,63 @@ final class StreamingTests: XCTestCase {
         tamperedFrame[tamperedFrame.index(before: tamperedFrame.endIndex)] ^= 1
         var tampered = try token.makeResponseDecryptor(responseNonce: responseNonce)
         XCTAssertThrowsError(try tampered.push(tamperedFrame))
+        XCTAssertThrowsError(try tampered.push(Data()))
+    }
+
+    func testResponseDecryptorParsesManyCoalescedFrames() throws {
+        let keyMaterial = try deriveResponseKeys(
+            exportedSecret: Data(repeating: 0xAB, count: EHBPConstants.exportLength),
+            requestEnc: Data(repeating: 0xCD, count: EHBPConstants.requestEncLength),
+            responseNonce: Data(repeating: 0xEF, count: EHBPConstants.responseNonceLength)
+        )
+        let chunkCount = 128
+        var framedData = Data()
+        var plaintexts = [Data]()
+
+        for index in 0..<chunkCount {
+            let plaintext = Data("coalesced chunk \(index)".utf8)
+            plaintexts.append(plaintext)
+            framedData.append(try framedChunk(
+                keyMaterial: keyMaterial,
+                sequence: UInt64(index),
+                plaintext: plaintext
+            ))
+        }
+
+        var decryptor = ResponseDecryptor(keyMaterial: keyMaterial)
+        XCTAssertEqual(try decryptor.push(framedData), plaintexts)
+        try decryptor.finish()
+    }
+
+    func testResponseDecryptorIngestsIndividualBytes() throws {
+        let keyMaterial = try deriveResponseKeys(
+            exportedSecret: Data(repeating: 0xAB, count: EHBPConstants.exportLength),
+            requestEnc: Data(repeating: 0xCD, count: EHBPConstants.requestEncLength),
+            responseNonce: Data(repeating: 0xEF, count: EHBPConstants.responseNonceLength)
+        )
+        let plaintexts = [
+            Data("first byte-fed chunk".utf8),
+            Data("second byte-fed chunk".utf8)
+        ]
+        var framedData = Data(repeating: 0, count: EHBPConstants.responseLengthPrefixBytes)
+        for (index, plaintext) in plaintexts.enumerated() {
+            framedData.append(try framedChunk(
+                keyMaterial: keyMaterial,
+                sequence: UInt64(index),
+                plaintext: plaintext
+            ))
+        }
+
+        var decryptor = ResponseDecryptor(keyMaterial: keyMaterial)
+        var opened = [Data]()
+        for byte in framedData {
+            if let plaintext = try decryptor.push(byte) {
+                opened.append(plaintext)
+            }
+        }
+
+        XCTAssertEqual(opened, plaintexts)
+        try decryptor.finish()
     }
 
     func testResponseDecryptorEnforcesSizeAndSequenceLimits() throws {
@@ -486,7 +543,10 @@ final class StreamingTests: XCTestCase {
             plaintext: plaintext
         )
         var length = UInt32(ciphertext.count).bigEndian
-        var frame = Data(bytes: &length, count: 4)
+        var frame = Data(
+            bytes: &length,
+            count: EHBPConstants.responseLengthPrefixBytes
+        )
         frame.append(ciphertext)
         return frame
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds incremental, authenticated stream recovery across Go, JS, Python, Rust, and Swift so recovered responses decrypt frame-by-frame before source EOF. Hardens validation to reject truncated framing, enforce sequence limits, and ensure cancelling the plaintext stream cancels the encrypted source.

- **New Features**
  - Spec: added Section 6.2.1 covering incremental recovery, replay, and tailing semantics.
  - Clients: introduced incremental response decryptors (`ResponseDecryptor`/`FrameDecryptor`) and token helpers to create them (`create_response_decryptor`/`response_decryptor`/`makeResponseDecryptor`).
  - Safety: detect truncated length prefixes or frames at EOF, cap chunk sizes, and guard sequence overflow during open/seal.
  - Streaming: handle zero-length frames and fragmented/coalesced chunks; deliver authenticated frames before EOF and propagate cancellation to the source body.

- **Dependencies**
  - Bumped to `0.3.0` for `ehbp` (JS) and `tinfoil-ehbp` (Python, Rust).

<sup>Written for commit 3fea677691c8387d9136ef709be84199bc099f70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

