### PR TITLE
fix: keep fetch options like credentials on encrypted requests

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -140,6 +140,7 @@ This derivation ensures:
 
   - Encrypt the request body when a non-empty payload body is present. Establish an HPKE sealer to the server public key (Section 4.4.1) and stream‑encrypt using the chunk framing in Section 4.3. Set `Ehbp-Encapsulated-Key` and use chunked transfer encoding without a Content-Length. Retain the HPKE sender context for response decryption.
   - When the request has no payload body, the request MUST be sent without `Ehbp-Encapsulated-Key` and the response will be unencrypted. See Section 7.4 for the security rationale.
+  - Clients that reconstruct the outbound request while encrypting (rather than mutating it in place) MUST preserve caller-supplied transport parameters — headers, cancellation, timeout, and credential/cookie and redirect policy — apart from the body-framing metadata EHBP manages (for example Content-Length) and the EHBP headers themselves. EHBP only seals the payload body; it does not alter how the request is otherwise transported.
 - Inbound response:
 
   - For requests with encrypted bodies: Require `Ehbp-Response-Nonce` (subject to the error pass-through rule below); derive response keys using the procedure in Section 4.4 (using the retained HPKE sender context from the request). Stream-decrypt the chunked body using the derived AES-256-GCM key.

--- a/client/client.go
+++ b/client/client.go
@@ -37,6 +37,11 @@ type Option func(*Transport)
 // requests (and, for NewTransport, to fetch the server key configuration). It
 // lets callers compose EHBP with a TLS-pinned or otherwise customized
 // http.Client. A nil client is ignored so the default remains in place.
+//
+// Encrypted requests are sent through the client's Transport only. Redirect
+// policy, cookie jar, and timeout are supplied by the outer http.Client that
+// drives this RoundTripper, not by the client passed here; the full client is
+// used for the key-configuration fetch.
 func WithHTTPClient(c *http.Client) Option {
 	return func(t *Transport) {
 		if c != nil {
@@ -183,6 +188,15 @@ func isKeyConfigMismatchResponse(resp *http.Response) (bool, string, error) {
 	return true, problem.Title, nil
 }
 
+// roundTripper returns the RoundTripper used to send encrypted requests,
+// honoring a Transport configured via WithHTTPClient.
+func (t *Transport) roundTripper() http.RoundTripper {
+	if t.httpClient.Transport != nil {
+		return t.httpClient.Transport
+	}
+	return http.DefaultTransport
+}
+
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Create a copy of the request to avoid modifying the original
 	newReq := req.Clone(req.Context())
@@ -218,7 +232,11 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		t.mu.Unlock()
 	}
 
-	resp, err := t.httpClient.Do(newReq)
+	// Send through a RoundTripper rather than a nested http.Client: a
+	// RoundTripper performs a single HTTP transaction, so redirects surface
+	// to the outer client, whose CheckRedirect and cookie jar then apply
+	// (and each redirected attempt is re-encrypted for its target).
+	resp, err := t.roundTripper().RoundTrip(newReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %v", err)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -158,6 +158,72 @@ func TestNewTransportWithIdentityRequiresIdentity(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// A RoundTripper must perform a single HTTP transaction: redirects have to
+// surface to the outer http.Client so its CheckRedirect policy and cookie jar
+// apply, instead of being swallowed by an internal client.
+func TestRoundTripSurfacesRedirectsToOuterClient(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+
+	middleware := serverIdentity.Middleware()
+	mux := http.NewServeMux()
+	mux.Handle("/redirect", middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		http.Redirect(w, r, "/secure", http.StatusTemporaryRedirect)
+	})))
+	mux.Handle("/secure", middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read request body", http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte("Hello, " + string(body)))
+	})))
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+	transport, err := NewTransportWithIdentity(pubIdentity)
+	assert.NoError(t, err)
+
+	t.Run("RoundTrip returns the redirect unfollowed", func(t *testing.T) {
+		req, err := http.NewRequest("POST", server.URL+"/redirect", bytes.NewBufferString("test"))
+		assert.NoError(t, err)
+
+		resp, err := transport.RoundTrip(req)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+		assert.Equal(t, "/secure", resp.Header.Get("Location"))
+	})
+
+	t.Run("outer client follows and re-encrypts each hop", func(t *testing.T) {
+		redirectsSeen := 0
+		httpClient := &http.Client{
+			Transport: transport,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				redirectsSeen++
+				return nil
+			},
+		}
+
+		req, err := http.NewRequest("POST", server.URL+"/redirect", bytes.NewBufferString("test"))
+		assert.NoError(t, err)
+
+		resp, err := httpClient.Do(req)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello, test", string(body))
+		assert.Equal(t, 1, redirectsSeen)
+	})
+}
+
 // TestTransportClearsRequestURI ensures the transport can carry a request that
 // originated as an inbound server request, which is how httputil.ReverseProxy
 // drives a RoundTripper. Such requests have RequestURI populated, and

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -2,6 +2,7 @@ import { Identity } from './identity.js';
 import { extractSessionRecoveryToken, decryptResponseWithToken } from './identity.js';
 import type { SessionRecoveryToken } from './identity.js';
 import { PROTOCOL } from './protocol.js';
+import { forwardedRequestInit } from './request-options.js';
 import { KeyConfigMismatchError, ProtocolError } from './errors.js';
 import type { Key } from 'hpke';
 
@@ -32,14 +33,15 @@ export class Transport {
 
   /**
    * Create a new transport by fetching server public key.
+   * The optional init is applied to the key fetch (e.g. credentials).
    */
-  static async create(serverURL: string): Promise<Transport> {
+  static async create(serverURL: string, init?: RequestInit): Promise<Transport> {
     const url = new URL(serverURL);
     const serverHost = url.host;
 
     // Fetch server public key
     const keysURL = new URL(PROTOCOL.KEYS_PATH, serverURL);
-    const response = await fetch(keysURL.toString());
+    const response = await fetch(keysURL.toString(), init);
 
     if (!response.ok) {
       throw new Error(`Failed to get server public key: ${response.status}`);
@@ -156,7 +158,12 @@ export class Transport {
 
     url.host = this.serverHost;
 
+    // Carry fetch options (credentials, signal, ...) through re-construction
+    // so they reach the final fetch of the encrypted request.
+    const forwardedInit = forwardedRequestInit(input instanceof Request ? input : init);
+
     const request = new Request(url.toString(), {
+      ...forwardedInit,
       method,
       headers,
       body: requestBody,
@@ -224,7 +231,8 @@ export class Transport {
 
 /**
  * Create a new transport instance.
+ * The optional init is applied to the server key fetch (e.g. credentials).
  */
-export async function createTransport(serverURL: string): Promise<Transport> {
-  return Transport.create(serverURL);
+export async function createTransport(serverURL: string, init?: RequestInit): Promise<Transport> {
+  return Transport.create(serverURL, init);
 }

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -159,8 +159,12 @@ export class Transport {
     url.host = this.serverHost;
 
     // Carry fetch options (credentials, signal, ...) through re-construction
-    // so they reach the final fetch of the encrypted request.
-    const forwardedInit = forwardedRequestInit(input instanceof Request ? input : init);
+    // so they reach the final fetch of the encrypted request. Like fetch(),
+    // init members override those of a Request input.
+    const forwardedInit =
+      input instanceof Request
+        ? { ...forwardedRequestInit(input), ...forwardedRequestInit(init) }
+        : forwardedRequestInit(init);
 
     const request = new Request(url.toString(), {
       ...forwardedInit,

--- a/js/src/identity.ts
+++ b/js/src/identity.ts
@@ -13,6 +13,7 @@ import {
   ResponseKeyMaterial,
 } from './derive.js';
 import { ProtocolError, DecryptionError } from './errors.js';
+import { forwardedRequestInit } from './request-options.js';
 
 /**
  * Request context for response decryption.
@@ -260,6 +261,7 @@ export class Identity {
     if (body.byteLength === 0) {
       return {
         request: new Request(request.url, {
+          ...forwardedRequestInit(request),
           method: request.method,
           headers: request.headers,
           body: null,
@@ -297,6 +299,7 @@ export class Identity {
 
     return {
       request: new Request(request.url, {
+        ...forwardedRequestInit(request),
         method: request.method,
         headers,
         body: chunkedData,

--- a/js/src/request-options.ts
+++ b/js/src/request-options.ts
@@ -1,0 +1,40 @@
+const FORWARDED_INIT_KEYS = [
+  'cache',
+  'credentials',
+  'integrity',
+  'keepalive',
+  'mode',
+  'redirect',
+  'referrer',
+  'referrerPolicy',
+  'signal',
+] as const;
+
+/**
+ * Extract the fetch options that must survive request re-construction
+ * (e.g. credentials for cross-origin cookies, signal for aborts).
+ *
+ * Works on both Request instances and plain RequestInit objects.
+ */
+export function forwardedRequestInit(source: Request | RequestInit | undefined): RequestInit {
+  const forwarded: RequestInit = {};
+  if (!source) {
+    return forwarded;
+  }
+
+  const record = source as unknown as Record<string, unknown>;
+  const target = forwarded as unknown as Record<string, unknown>;
+  for (const key of FORWARDED_INIT_KEYS) {
+    const value = record[key];
+    if (value !== undefined) {
+      target[key] = value;
+    }
+  }
+
+  // 'navigate' is a browser-internal mode that the Request constructor rejects.
+  if (forwarded.mode === 'navigate') {
+    delete forwarded.mode;
+  }
+
+  return forwarded;
+}

--- a/js/src/test/client.test.ts
+++ b/js/src/test/client.test.ts
@@ -375,6 +375,37 @@ describe('Transport', () => {
     }
   });
 
+  it('should let init options override a Request input, like fetch()', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+
+    const originalFetch = globalThis.fetch;
+    let capturedRequest!: Request;
+
+    globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      capturedRequest = input as Request;
+      return buildEncryptedResponse(capturedRequest.clone(), serverIdentity);
+    }) as typeof fetch;
+
+    try {
+      const request = new Request('https://server.test/secure', {
+        method: 'POST',
+        body: 'hello',
+        credentials: 'include',
+        redirect: 'manual',
+        duplex: 'half',
+      } as RequestInit);
+      const response = await transport.request(request, { credentials: 'omit' });
+      assert.strictEqual(await response.text(), 'processed:hello');
+
+      // init overrides the Request; unset init members fall back to it
+      assert.strictEqual(capturedRequest.credentials, 'omit');
+      assert.strictEqual(capturedRequest.redirect, 'manual');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('should preserve fetch options on bodyless passthrough requests', async () => {
     const serverIdentity = await Identity.generate();
     const transport = new Transport(serverIdentity, 'server.test');

--- a/js/src/test/client.test.ts
+++ b/js/src/test/client.test.ts
@@ -315,6 +315,115 @@ describe('Transport', () => {
     }
   });
 
+  it('should preserve fetch options on the encrypted request', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+
+    const originalFetch = globalThis.fetch;
+    let capturedRequest!: Request;
+
+    globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      capturedRequest = input as Request;
+      return buildEncryptedResponse(capturedRequest.clone(), serverIdentity);
+    }) as typeof fetch;
+
+    try {
+      const controller = new AbortController();
+      const response = await transport.post('https://server.test/secure', 'hello', {
+        credentials: 'include',
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+      assert.strictEqual(await response.text(), 'processed:hello');
+
+      assert.strictEqual(capturedRequest.credentials, 'include');
+      assert.strictEqual(capturedRequest.redirect, 'manual');
+
+      // The outgoing request's signal must follow the caller's signal
+      assert.strictEqual(capturedRequest.signal.aborted, false);
+      controller.abort();
+      assert.strictEqual(capturedRequest.signal.aborted, true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should preserve fetch options when input is a Request instance', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+
+    const originalFetch = globalThis.fetch;
+    let capturedRequest!: Request;
+
+    globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      capturedRequest = input as Request;
+      return buildEncryptedResponse(capturedRequest.clone(), serverIdentity);
+    }) as typeof fetch;
+
+    try {
+      const request = new Request('https://server.test/secure', {
+        method: 'POST',
+        body: 'hello',
+        credentials: 'include',
+        duplex: 'half',
+      } as RequestInit);
+      const response = await transport.request(request);
+      assert.strictEqual(await response.text(), 'processed:hello');
+      assert.strictEqual(capturedRequest.credentials, 'include');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should preserve fetch options on bodyless passthrough requests', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+
+    const originalFetch = globalThis.fetch;
+    let capturedRequest!: Request;
+
+    globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      capturedRequest = input as Request;
+      return new Response('plain', { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const response = await transport.get('https://server.test/status', {
+        credentials: 'include',
+      });
+      assert.strictEqual(await response.text(), 'plain');
+      assert.strictEqual(capturedRequest.credentials, 'include');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should pass init to the key fetch in createTransport', async () => {
+    const serverIdentity = await Identity.generate();
+    const config = await serverIdentity.marshalConfig();
+
+    const originalFetch = globalThis.fetch;
+    let capturedInit: RequestInit | undefined;
+
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit
+    ): Promise<Response> => {
+      capturedInit = init;
+      return new Response(toArrayBuffer(config), {
+        status: 200,
+        headers: { 'content-type': PROTOCOL.KEYS_MEDIA_TYPE },
+      });
+    }) as typeof fetch;
+
+    try {
+      await createTransport('https://server.test', { credentials: 'include' });
+      assert.strictEqual(capturedInit?.credentials, 'include');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('should decrypt a response with a nonce regardless of HTTP status', async () => {
     const serverIdentity = await Identity.generate();
     const transport = new Transport(serverIdentity, 'server.test');


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves fetch options like `credentials`, `redirect`, and `signal` on encrypted requests and lets redirects surface to the caller so cookie and redirect policies apply. You can also pass `RequestInit` to the key fetch; the SPEC now requires clients to preserve caller transport options.

- **Bug Fixes**
  - JS: Preserve caller `RequestInit` on reconstructed `Request`s (including bodyless passthrough and `Request` inputs); per-call `init` overrides a `Request` input like `fetch()`; strip unsupported `mode: 'navigate'`; `createTransport(serverURL, init?)` and `Transport.create(..., init?)` pass `init` to the key fetch so `credentials` (cookies) are respected.
  - Go: Send via the configured `RoundTripper` so redirects surface to the outer `http.Client` (its `CheckRedirect` and cookie jar apply) and each hop is re-encrypted.

<sup>Written for commit 75246de2fcf5fe26ef0810d0e6ecfc30e740a766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

