### PR TITLE
fix: preserve request and recovery state integrity

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -21,11 +21,36 @@ type Transport struct {
 
 	mu                       sync.Mutex
 	lastSessionRecoveryToken *identity.SessionRecoveryToken
+	requestGeneration        uint64
 }
 
 type problemDetails struct {
 	Type  string `json:"type"`
 	Title string `json:"title"`
+}
+
+const maxProblemDetailsBytes = 64 << 10
+
+type preservingReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+type tokenOwningReadCloser struct {
+	io.ReadCloser
+	onComplete func()
+	onError    func()
+	once       sync.Once
+}
+
+func (r *tokenOwningReadCloser) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if err == io.EOF {
+		r.once.Do(r.onComplete)
+	} else if err != nil {
+		r.once.Do(r.onError)
+	}
+	return n, err
 }
 
 var _ http.RoundTripper = (*Transport)(nil)
@@ -170,9 +195,16 @@ func isKeyConfigMismatchResponse(resp *http.Response) (bool, string, error) {
 		return false, "", nil
 	}
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxProblemDetailsBytes+1))
 	if err != nil {
 		return false, "", fmt.Errorf("failed to read problem response: %w", err)
+	}
+	if len(bodyBytes) > maxProblemDetailsBytes {
+		resp.Body = &preservingReadCloser{
+			Reader: io.MultiReader(bytes.NewReader(bodyBytes), resp.Body),
+			Closer: resp.Body,
+		}
+		return false, "", nil
 	}
 	_ = resp.Body.Close()
 	resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
@@ -198,6 +230,12 @@ func (t *Transport) roundTripper() http.RoundTripper {
 }
 
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	t.requestGeneration++
+	generation := t.requestGeneration
+	t.lastSessionRecoveryToken = nil
+	t.mu.Unlock()
+
 	// Create a copy of the request to avoid modifying the original
 	newReq := req.Clone(req.Context())
 
@@ -223,13 +261,6 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract session recovery token: %v", err)
 		}
-	}
-
-	// Clear token for bodyless requests immediately
-	if reqCtx == nil {
-		t.mu.Lock()
-		t.lastSessionRecoveryToken = nil
-		t.mu.Unlock()
 	}
 
 	// Send through a RoundTripper rather than a nested http.Client: a
@@ -267,8 +298,28 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 
 		t.mu.Lock()
-		t.lastSessionRecoveryToken = token
+		if t.requestGeneration == generation {
+			t.lastSessionRecoveryToken = token
+		}
 		t.mu.Unlock()
+
+		resp.Body = &tokenOwningReadCloser{
+			ReadCloser: resp.Body,
+			onComplete: func() {
+				t.mu.Lock()
+				if t.requestGeneration == generation {
+					t.lastSessionRecoveryToken = nil
+				}
+				t.mu.Unlock()
+			},
+			onError: func() {
+				t.mu.Lock()
+				if t.requestGeneration == generation {
+					t.lastSessionRecoveryToken = nil
+				}
+				t.mu.Unlock()
+			},
+		}
 	}
 
 	return resp, nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -371,6 +371,64 @@ func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	return r.inner.RoundTrip(req)
 }
 
+type corruptingRoundTripper struct {
+	inner http.RoundTripper
+}
+
+func (r corruptingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := r.inner.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Header.Get(protocol.ResponseNonceHeader) == "" {
+		return resp, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		resp.Body.Close()
+		return nil, err
+	}
+	resp.Body.Close()
+	body[len(body)-1] ^= 1
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return resp, nil
+}
+
+type firstResponseCorruptingRoundTripper struct {
+	inner http.RoundTripper
+	mu    sync.Mutex
+	count int
+}
+
+func (r *firstResponseCorruptingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := r.inner.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Header.Get(protocol.ResponseNonceHeader) == "" {
+		return resp, nil
+	}
+
+	r.mu.Lock()
+	r.count++
+	shouldCorrupt := r.count == 1
+	r.mu.Unlock()
+	if !shouldCorrupt {
+		return resp, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		resp.Body.Close()
+		return nil, err
+	}
+	resp.Body.Close()
+	body[len(body)-1] ^= 1
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return resp, nil
+}
+
 func TestWithHTTPClient(t *testing.T) {
 	serverIdentity, err := identity.NewIdentity()
 	assert.NoError(t, err)
@@ -568,19 +626,33 @@ func TestTransportGetSessionRecoveryToken(t *testing.T) {
 		assert.Nil(t, token)
 	})
 
-	t.Run("available after POST with body", func(t *testing.T) {
+	t.Run("cleared after successful full response consumption", func(t *testing.T) {
 		req, err := http.NewRequest("POST", server.URL+"/secure", bytes.NewBuffer([]byte("test")))
 		assert.NoError(t, err)
 
 		resp, err := httpClient.Do(req)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
-		io.ReadAll(resp.Body)
 
 		token := transport.GetSessionRecoveryToken()
 		assert.NotNil(t, token)
 		assert.Len(t, token.ExportedSecret, 32)
 		assert.Len(t, token.RequestEnc, 32)
+
+		_, err = io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Nil(t, transport.GetSessionRecoveryToken())
+	})
+
+	t.Run("retained after response body is closed before EOF", func(t *testing.T) {
+		req, err := http.NewRequest("POST", server.URL+"/secure", bytes.NewBuffer([]byte("test")))
+		assert.NoError(t, err)
+
+		resp, err := httpClient.Do(req)
+		assert.NoError(t, err)
+		assert.NoError(t, resp.Body.Close())
+
+		assert.NotNil(t, transport.GetSessionRecoveryToken())
 	})
 
 	t.Run("updates on each new request", func(t *testing.T) {
@@ -617,4 +689,229 @@ func TestTransportGetSessionRecoveryToken(t *testing.T) {
 		assert.Nil(t, transport.GetSessionRecoveryToken(),
 			"Token should be cleared after bodyless request")
 	})
+}
+
+func TestTransportLatestRequestOwnsRecoveryToken(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	server := httptest.NewServer(serverIdentity.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		assert.NoError(t, readErr)
+		if string(body) == "first" {
+			close(firstStarted)
+			<-releaseFirst
+		}
+		_, _ = w.Write([]byte("ok"))
+	})))
+	defer server.Close()
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+	transport, err := NewTransportWithIdentity(pubIdentity)
+	assert.NoError(t, err)
+	httpClient := &http.Client{Transport: transport}
+
+	firstResult := make(chan error, 1)
+	go func() {
+		req, reqErr := http.NewRequest("POST", server.URL, bytes.NewBufferString("first"))
+		if reqErr != nil {
+			firstResult <- reqErr
+			return
+		}
+		resp, doErr := httpClient.Do(req)
+		if doErr == nil {
+			resp.Body.Close()
+		}
+		firstResult <- doErr
+	}()
+
+	<-firstStarted
+	secondReq, err := http.NewRequest("POST", server.URL, bytes.NewBufferString("second"))
+	assert.NoError(t, err)
+	secondResp, err := httpClient.Do(secondReq)
+	assert.NoError(t, err)
+	secondResp.Body.Close()
+	secondToken := append([]byte(nil), transport.GetSessionRecoveryToken().RequestEnc...)
+
+	close(releaseFirst)
+	assert.NoError(t, <-firstResult)
+	assert.Equal(t, secondToken, transport.GetSessionRecoveryToken().RequestEnc,
+		"an older response must not replace the latest token")
+}
+
+func TestTransportInvalidatesRecoveryTokenWhenRequestStarts(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+
+	blockedStarted := make(chan struct{})
+	releaseBlocked := make(chan struct{})
+	server := httptest.NewServer(serverIdentity.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		assert.NoError(t, readErr)
+		if string(body) == "blocked" {
+			close(blockedStarted)
+			<-releaseBlocked
+		}
+		_, _ = w.Write([]byte("ok"))
+	})))
+	defer server.Close()
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+	transport, err := NewTransportWithIdentity(pubIdentity)
+	assert.NoError(t, err)
+	httpClient := &http.Client{Transport: transport}
+
+	initialReq, err := http.NewRequest("POST", server.URL, bytes.NewBufferString("initial"))
+	assert.NoError(t, err)
+	initialResp, err := httpClient.Do(initialReq)
+	assert.NoError(t, err)
+	initialResp.Body.Close()
+	assert.NotNil(t, transport.GetSessionRecoveryToken())
+
+	blockedResult := make(chan error, 1)
+	go func() {
+		req, reqErr := http.NewRequest("POST", server.URL, bytes.NewBufferString("blocked"))
+		if reqErr != nil {
+			blockedResult <- reqErr
+			return
+		}
+		resp, doErr := httpClient.Do(req)
+		if doErr == nil {
+			resp.Body.Close()
+		}
+		blockedResult <- doErr
+	}()
+
+	<-blockedStarted
+	assert.Nil(t, transport.GetSessionRecoveryToken())
+	close(releaseBlocked)
+	assert.NoError(t, <-blockedResult)
+	assert.NotNil(t, transport.GetSessionRecoveryToken())
+}
+
+func TestTransportClearsRecoveryTokenAfterStreamFailure(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+	server := httptest.NewServer(serverIdentity.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte("encrypted response"))
+	})))
+	defer server.Close()
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+	transport, err := NewTransportWithIdentity(pubIdentity, WithHTTPClient(&http.Client{
+		Transport: corruptingRoundTripper{inner: http.DefaultTransport},
+	}))
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest("POST", server.URL, bytes.NewBufferString("request"))
+	assert.NoError(t, err)
+	resp, err := transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, transport.GetSessionRecoveryToken())
+
+	_, err = io.ReadAll(resp.Body)
+	assert.ErrorContains(t, err, "failed to decrypt chunk")
+	assert.Nil(t, transport.GetSessionRecoveryToken())
+}
+
+func TestOlderStreamFailurePreservesNewerRecoveryToken(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+	server := httptest.NewServer(serverIdentity.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte("encrypted response"))
+	})))
+	defer server.Close()
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+	corruptingTransport := &firstResponseCorruptingRoundTripper{inner: http.DefaultTransport}
+	transport, err := NewTransportWithIdentity(pubIdentity, WithHTTPClient(&http.Client{
+		Transport: corruptingTransport,
+	}))
+	assert.NoError(t, err)
+
+	firstReq, err := http.NewRequest("POST", server.URL, bytes.NewBufferString("first"))
+	assert.NoError(t, err)
+	firstResp, err := transport.RoundTrip(firstReq)
+	assert.NoError(t, err)
+	defer firstResp.Body.Close()
+
+	secondReq, err := http.NewRequest("POST", server.URL, bytes.NewBufferString("second"))
+	assert.NoError(t, err)
+	secondResp, err := transport.RoundTrip(secondReq)
+	assert.NoError(t, err)
+	defer secondResp.Body.Close()
+	newerToken := append([]byte(nil), transport.GetSessionRecoveryToken().RequestEnc...)
+
+	_, err = io.ReadAll(firstResp.Body)
+	assert.ErrorContains(t, err, "failed to decrypt chunk")
+	assert.Equal(t, newerToken, transport.GetSessionRecoveryToken().RequestEnc)
+}
+
+func TestOlderStreamCompletionPreservesNewerRecoveryToken(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+	server := httptest.NewServer(serverIdentity.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte("encrypted response"))
+	})))
+	defer server.Close()
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+	transport, err := NewTransportWithIdentity(pubIdentity)
+	assert.NoError(t, err)
+
+	firstReq, err := http.NewRequest("POST", server.URL, bytes.NewBufferString("first"))
+	assert.NoError(t, err)
+	firstResp, err := transport.RoundTrip(firstReq)
+	assert.NoError(t, err)
+	defer firstResp.Body.Close()
+
+	secondReq, err := http.NewRequest("POST", server.URL, bytes.NewBufferString("second"))
+	assert.NoError(t, err)
+	secondResp, err := transport.RoundTrip(secondReq)
+	assert.NoError(t, err)
+	defer secondResp.Body.Close()
+	newerToken := append([]byte(nil), transport.GetSessionRecoveryToken().RequestEnc...)
+
+	_, err = io.ReadAll(firstResp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, newerToken, transport.GetSessionRecoveryToken().RequestEnc)
+}
+
+func TestTransportBoundsProblemDetailsParsing(t *testing.T) {
+	serverIdentity, err := identity.NewIdentity()
+	assert.NoError(t, err)
+	body := `{"type":"` + protocol.KeyConfigProblemType + `","title":"` +
+		strings.Repeat("x", maxProblemDetailsBytes) + `"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", protocol.ProblemJSONMediaType)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	pubIdentity, err := identity.FromPublicKeyHex(serverIdentity.MarshalPublicKeyHex())
+	assert.NoError(t, err)
+	transport, err := NewTransportWithIdentity(pubIdentity)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest("POST", server.URL, bytes.NewBufferString("request"))
+	assert.NoError(t, err)
+	resp, err := transport.RoundTrip(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	got, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, body, string(got))
 }

--- a/identity/crypt.go
+++ b/identity/crypt.go
@@ -449,14 +449,18 @@ const maxResponseChunkBytes = 64 << 20
 // It emits each plaintext chunk as soon as the complete encrypted frame has
 // been authenticated and rejects truncated framing at end-of-stream.
 type DerivedStreamingDecryptReader struct {
-	reader io.Reader
-	aead   *ResponseAEAD
-	buffer []byte
-	eof    bool
+	reader      io.Reader
+	aead        *ResponseAEAD
+	buffer      []byte
+	eof         bool
+	terminalErr error
 }
 
 // Read implements io.Reader, decrypting chunks as they are read.
 func (r *DerivedStreamingDecryptReader) Read(p []byte) (n int, err error) {
+	if r.terminalErr != nil {
+		return 0, r.terminalErr
+	}
 	if r.eof {
 		return 0, io.EOF
 	}
@@ -478,7 +482,7 @@ func (r *DerivedStreamingDecryptReader) Read(p []byte) (n int, err error) {
 				r.eof = true
 				return 0, io.EOF
 			}
-			return 0, fmt.Errorf("failed to read chunk length: %w", err)
+			return 0, r.fail(fmt.Errorf("failed to read chunk length: %w", err))
 		}
 
 		chunkLen := binary.BigEndian.Uint32(chunkLenBytes)
@@ -486,20 +490,20 @@ func (r *DerivedStreamingDecryptReader) Read(p []byte) (n int, err error) {
 			continue
 		}
 		if chunkLen > maxResponseChunkBytes {
-			return 0, fmt.Errorf("encrypted response chunk exceeds maximum allowed size")
+			return 0, r.fail(fmt.Errorf("encrypted response chunk exceeds maximum allowed size"))
 		}
 
 		// Read encrypted chunk
 		encryptedChunk := make([]byte, chunkLen)
 		_, err = io.ReadFull(r.reader, encryptedChunk)
 		if err != nil {
-			return 0, fmt.Errorf("failed to read encrypted chunk: %w", err)
+			return 0, r.fail(fmt.Errorf("failed to read encrypted chunk: %w", err))
 		}
 
 		// Decrypt chunk (nonce is computed and sequence incremented automatically)
 		decryptedChunk, err := r.aead.Open(encryptedChunk, nil)
 		if err != nil {
-			return 0, fmt.Errorf("failed to decrypt chunk: %w", err)
+			return 0, r.fail(fmt.Errorf("failed to decrypt chunk: %w", err))
 		}
 
 		// Return as much as fits, buffer the rest
@@ -510,6 +514,11 @@ func (r *DerivedStreamingDecryptReader) Read(p []byte) (n int, err error) {
 
 		return n, nil
 	}
+}
+
+func (r *DerivedStreamingDecryptReader) fail(err error) error {
+	r.terminalErr = err
+	return err
 }
 
 func (r *DerivedStreamingDecryptReader) Close() error {

--- a/identity/derive.go
+++ b/identity/derive.go
@@ -148,8 +148,12 @@ func (r *ResponseAEAD) Open(ciphertext, aad []byte) ([]byte, error) {
 		return nil, fmt.Errorf("response chunk sequence overflow")
 	}
 	nonce := r.computeNonce()
+	plaintext, err := r.aead.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return nil, err
+	}
 	r.seq++
-	return r.aead.Open(nil, nonce, ciphertext, aad)
+	return plaintext, nil
 }
 
 // OpenWithSeq decrypts ciphertext using a specific sequence number without

--- a/identity/derive_test.go
+++ b/identity/derive_test.go
@@ -389,6 +389,40 @@ func TestWrongSequenceNumberFails(t *testing.T) {
 	}
 }
 
+func TestResponseAEADOpenAdvancesOnlyAfterAuthentication(t *testing.T) {
+	km := &ResponseKeyMaterial{
+		Key:       make([]byte, AES256KeyLength),
+		NonceBase: make([]byte, AESGCMNonceLength),
+	}
+	sealer, err := km.NewResponseAEAD()
+	if err != nil {
+		t.Fatalf("NewResponseAEAD failed: %v", err)
+	}
+	opener, err := km.NewResponseAEAD()
+	if err != nil {
+		t.Fatalf("NewResponseAEAD failed: %v", err)
+	}
+
+	ciphertext := sealer.Seal([]byte("authenticated"), nil)
+	tampered := append([]byte(nil), ciphertext...)
+	tampered[len(tampered)-1] ^= 1
+
+	if _, err := opener.Open(tampered, nil); err == nil {
+		t.Fatal("tampered ciphertext should fail authentication")
+	}
+	if opener.Seq() != 0 {
+		t.Fatalf("failed authentication advanced sequence to %d", opener.Seq())
+	}
+
+	plaintext, err := opener.Open(ciphertext, nil)
+	if err != nil {
+		t.Fatalf("valid ciphertext should still decrypt: %v", err)
+	}
+	if !bytes.Equal(plaintext, []byte("authenticated")) {
+		t.Fatalf("unexpected plaintext: %q", plaintext)
+	}
+}
+
 func TestDifferentKeysCannotDecrypt(t *testing.T) {
 	// Server's key material
 	serverSecret := make([]byte, 32)

--- a/identity/session_recovery_test.go
+++ b/identity/session_recovery_test.go
@@ -307,6 +307,10 @@ func TestDecryptResponseWithTokenRejectsTruncatedLengthPrefix(t *testing.T) {
 	_, err := io.ReadAll(resp.Body)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "chunk length")
+
+	_, repeatedErr := resp.Body.Read(make([]byte, 1))
+	require.Error(t, repeatedErr)
+	assert.Equal(t, err.Error(), repeatedErr.Error())
 }
 
 func TestDecryptResponseWithTokenCloseCancelsSource(t *testing.T) {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -11,6 +11,8 @@ interface ProblemDetails {
   title?: string;
 }
 
+const MAX_PROBLEM_DETAILS_BYTES = 64 * 1024;
+
 /**
  * HTTP transport for EHBP
  */
@@ -18,6 +20,7 @@ export class Transport {
   private serverIdentity: Identity;
   private serverHost: string;
   private _lastSessionRecoveryToken?: SessionRecoveryToken;
+  private requestGeneration = 0;
 
   constructor(serverIdentity: Identity, serverHost: string) {
     this.serverIdentity = serverIdentity;
@@ -72,7 +75,30 @@ export class Transport {
 
     let problem: ProblemDetails | undefined;
     try {
-      problem = (await response.clone().json()) as ProblemDetails;
+      const clone = response.clone();
+      if (!clone.body) return;
+
+      const reader = clone.body.getReader();
+      const chunks: Uint8Array[] = [];
+      let length = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        length += value.byteLength;
+        if (length > MAX_PROBLEM_DETAILS_BYTES) {
+          reader.cancel().catch(() => {});
+          return;
+        }
+        chunks.push(value);
+      }
+
+      const body = new Uint8Array(length);
+      let offset = 0;
+      for (const chunk of chunks) {
+        body.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      problem = JSON.parse(new TextDecoder().decode(body)) as ProblemDetails;
     } catch {
       return; // Not valid JSON — not a key config mismatch
     }
@@ -122,54 +148,29 @@ export class Transport {
    * Make an encrypted HTTP request.
    */
   async request(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const generation = ++this.requestGeneration;
+    this._lastSessionRecoveryToken = undefined;
+
     // Skip EHBP for non-network URLs (data:, blob:)
     const inputUrl = input instanceof Request ? input.url : String(input);
     if (inputUrl.startsWith('data:') || inputUrl.startsWith('blob:')) {
       return fetch(input, init);
     }
 
-    // Extract body from init or original request before creating Request object
-    let requestBody: BodyInit | null = null;
+    // Normalize through the platform Request constructor first so RequestInit
+    // overrides a Request input with the same semantics as fetch().
+    const normalizedRequest = new Request(input, init);
+    const requestBody = normalizedRequest.body
+      ? await normalizedRequest.arrayBuffer()
+      : null;
 
-    if (input instanceof Request) {
-      // If input is a Request, extract its body
-      if (input.body) {
-        requestBody = await input.arrayBuffer();
-      }
-    } else {
-      // If input is URL/string, get body from init
-      requestBody = init?.body || null;
-    }
-
-    // Create the URL with correct host
-    let url: URL;
-    let method: string;
-    let headers: HeadersInit;
-
-    if (input instanceof Request) {
-      url = new URL(input.url);
-      method = input.method;
-      headers = input.headers;
-    } else {
-      url = new URL(input);
-      method = init?.method || 'GET';
-      headers = init?.headers || {};
-    }
-
+    const url = new URL(normalizedRequest.url);
     url.host = this.serverHost;
 
-    // Carry fetch options (credentials, signal, ...) through re-construction
-    // so they reach the final fetch of the encrypted request. Like fetch(),
-    // init members override those of a Request input.
-    const forwardedInit =
-      input instanceof Request
-        ? { ...forwardedRequestInit(input), ...forwardedRequestInit(init) }
-        : forwardedRequestInit(init);
-
     const request = new Request(url.toString(), {
-      ...forwardedInit,
-      method,
-      headers,
+      ...forwardedRequestInit(normalizedRequest),
+      method: normalizedRequest.method,
+      headers: normalizedRequest.headers,
       body: requestBody,
       duplex: 'half',
     } as RequestInit);
@@ -188,7 +189,6 @@ export class Transport {
 
     // Bodyless requests: context is null, response is plaintext
     if (!token) {
-      this._lastSessionRecoveryToken = undefined;
       return response;
     }
 
@@ -197,11 +197,26 @@ export class Transport {
       return response;
     }
 
-    // Publish token only after confirming the response is valid
-    this._lastSessionRecoveryToken = token;
-
     // Decrypt response using the already-extracted token
-    return await decryptResponseWithToken(response, token);
+    let streamTerminated = false;
+    const clearToken = () => {
+      streamTerminated = true;
+      if (this.requestGeneration === generation) {
+        this._lastSessionRecoveryToken = undefined;
+      }
+    };
+    const decryptedResponse = await decryptResponseWithToken(
+      response,
+      token,
+      clearToken,
+      clearToken,
+    );
+
+    // Publish token only after confirming the response is valid
+    if (this.requestGeneration === generation) {
+      this._lastSessionRecoveryToken = streamTerminated ? undefined : token;
+    }
+    return decryptedResponse;
   }
 
   /**

--- a/js/src/identity.ts
+++ b/js/src/identity.ts
@@ -373,6 +373,8 @@ export function deserializeSessionRecoveryToken(json: string): SessionRecoveryTo
 export async function decryptResponseWithToken(
   response: Response,
   token: SessionRecoveryToken,
+  onStreamError?: () => void,
+  onStreamComplete?: () => void,
 ): Promise<Response> {
   if (!response.body) return response;
 
@@ -387,7 +389,12 @@ export async function decryptResponseWithToken(
   }
 
   const km = await deriveResponseKeys(token.exportedSecret, token.requestEnc, responseNonce);
-  const decryptedStream = createDecryptStream(response.body, km);
+  const decryptedStream = createDecryptStream(
+    response.body,
+    km,
+    onStreamError,
+    onStreamComplete,
+  );
 
   // Framing headers describe the encrypted body, not the decrypted stream.
   // Consumers that forward the response headers verbatim (for example a
@@ -409,10 +416,13 @@ const MAX_RESPONSE_CHUNK_BYTES = 64 * 1024 * 1024;
 function createDecryptStream(
   body: ReadableStream<Uint8Array>,
   km: ResponseKeyMaterial,
+  onStreamError?: () => void,
+  onStreamComplete?: () => void,
 ): ReadableStream<Uint8Array> {
   let buffer = new Uint8Array(0);
   let seq = 0;
   const reader = body.getReader();
+  let consumerCancelled = false;
 
   return new ReadableStream({
     async pull(controller) {
@@ -420,6 +430,7 @@ function createDecryptStream(
       // so the upstream body must be cancelled explicitly; otherwise a rejected
       // (e.g. oversized) chunk leaves the underlying response downloading.
       const fail = (error: Error) => {
+        onStreamError?.();
         controller.error(error);
         reader.cancel(error).catch(() => {});
       };
@@ -457,11 +468,27 @@ function createDecryptStream(
           }
         }
 
-        const { done, value } = await reader.read();
+        let result: ReadableStreamReadResult<Uint8Array>;
+        try {
+          result = await reader.read();
+        } catch (error) {
+          if (consumerCancelled) {
+            return;
+          }
+          fail(error instanceof Error ? error : new Error('Encrypted response read failed', {
+            cause: error,
+          }));
+          return;
+        }
+        const { done, value } = result;
         if (done) {
+          if (consumerCancelled) {
+            return;
+          }
           if (buffer.length !== 0) {
             fail(new ProtocolError('truncated encrypted response chunk'));
           } else {
+            onStreamComplete?.();
             controller.close();
           }
           return;
@@ -474,6 +501,7 @@ function createDecryptStream(
       }
     },
     cancel(reason) {
+      consumerCancelled = true;
       return reader.cancel(reason);
     },
   });

--- a/js/src/identity.ts
+++ b/js/src/identity.ts
@@ -376,7 +376,12 @@ export async function decryptResponseWithToken(
   onStreamError?: () => void,
   onStreamComplete?: () => void,
 ): Promise<Response> {
-  if (!response.body) return response;
+  if (!response.body) {
+    if (response.headers.has(PROTOCOL.RESPONSE_NONCE_HEADER)) {
+      onStreamComplete?.();
+    }
+    return response;
+  }
 
   const responseNonceHex = response.headers.get(PROTOCOL.RESPONSE_NONCE_HEADER);
   if (!responseNonceHex) {
@@ -430,9 +435,16 @@ function createDecryptStream(
       // so the upstream body must be cancelled explicitly; otherwise a rejected
       // (e.g. oversized) chunk leaves the underlying response downloading.
       const fail = (error: Error) => {
-        onStreamError?.();
-        controller.error(error);
-        reader.cancel(error).catch(() => {});
+        try {
+          onStreamError?.();
+        } catch {
+          // Observer failures must not interrupt stream cleanup.
+        }
+        try {
+          controller.error(error);
+        } finally {
+          reader.cancel(error).catch(() => {});
+        }
       };
 
       while (true) {

--- a/js/src/identity.ts
+++ b/js/src/identity.ts
@@ -376,14 +376,11 @@ export async function decryptResponseWithToken(
   onStreamError?: () => void,
   onStreamComplete?: () => void,
 ): Promise<Response> {
-  if (!response.body) {
-    if (response.headers.has(PROTOCOL.RESPONSE_NONCE_HEADER)) {
-      onStreamComplete?.();
-    }
+  const responseNonceHex = response.headers.get(PROTOCOL.RESPONSE_NONCE_HEADER);
+  if (!response.body && !responseNonceHex) {
     return response;
   }
 
-  const responseNonceHex = response.headers.get(PROTOCOL.RESPONSE_NONCE_HEADER);
   if (!responseNonceHex) {
     throw new ProtocolError(`Missing ${PROTOCOL.RESPONSE_NONCE_HEADER} header`);
   }
@@ -391,6 +388,10 @@ export async function decryptResponseWithToken(
   const responseNonce = hexToBytes(responseNonceHex);
   if (responseNonce.length !== RESPONSE_NONCE_LENGTH) {
     throw new ProtocolError(`Invalid response nonce length`);
+  }
+  if (!response.body) {
+    onStreamComplete?.();
+    return response;
   }
 
   const km = await deriveResponseKeys(token.exportedSecret, token.requestEnc, responseNonce);

--- a/js/src/test/client.test.ts
+++ b/js/src/test/client.test.ts
@@ -345,6 +345,38 @@ describe('Transport', () => {
     }
   });
 
+  it('should not publish a token for a nonce-bearing null-body response', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      const request = input instanceof Request ? input : new Request(input);
+      assert(request.headers.has(PROTOCOL.ENCAPSULATED_KEY_HEADER));
+      return new Response(null, {
+        status: 204,
+        headers: {
+          [PROTOCOL.RESPONSE_NONCE_HEADER]: bytesToHex(
+            new Uint8Array(RESPONSE_NONCE_LENGTH)
+          ),
+        },
+      });
+    }) as typeof fetch;
+
+    try {
+      const response = await transport.post('https://server.test/secure', 'hello');
+
+      assert.strictEqual(response.status, 204);
+      assert.strictEqual(response.body, null);
+      assert.throws(
+        () => transport.getSessionRecoveryToken(),
+        /No session recovery token available/
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('should retain the recovery token when the consumer cancels before EOF', async () => {
     const serverIdentity = await Identity.generate();
     const transport = new Transport(serverIdentity, 'server.test');

--- a/js/src/test/client.test.ts
+++ b/js/src/test/client.test.ts
@@ -377,6 +377,30 @@ describe('Transport', () => {
     }
   });
 
+  it('should reject a malformed nonce on a null-body response', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (): Promise<Response> => new Response(null, {
+      status: 204,
+      headers: { [PROTOCOL.RESPONSE_NONCE_HEADER]: '00' },
+    })) as typeof fetch;
+
+    try {
+      await assert.rejects(
+        () => transport.post('https://server.test/secure', 'hello'),
+        /Invalid response nonce length/
+      );
+      assert.throws(
+        () => transport.getSessionRecoveryToken(),
+        /No session recovery token available/
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('should retain the recovery token when the consumer cancels before EOF', async () => {
     const serverIdentity = await Identity.generate();
     const transport = new Transport(serverIdentity, 'server.test');

--- a/js/src/test/client.test.ts
+++ b/js/src/test/client.test.ts
@@ -271,6 +271,31 @@ describe('Transport', () => {
     }
   });
 
+  it('should bound key mismatch problem parsing without consuming pass-through', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+    const oversizedProblem = JSON.stringify({
+      type: PROTOCOL.KEY_CONFIG_PROBLEM_TYPE,
+      title: 'x'.repeat(64 * 1024),
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (): Promise<Response> => {
+      return new Response(oversizedProblem, {
+        status: 422,
+        headers: { 'content-type': PROTOCOL.PROBLEM_JSON_MEDIA_TYPE },
+      });
+    }) as typeof fetch;
+
+    try {
+      const response = await transport.post('https://server.test/secure', 'hello');
+      assert.strictEqual(response.status, 422);
+      assert.strictEqual(await response.text(), oversizedProblem);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('should reject a nonce-less 2xx response', async () => {
     const serverIdentity = await Identity.generate();
     const transport = new Transport(serverIdentity, 'server.test');
@@ -308,8 +333,96 @@ describe('Transport', () => {
 
     try {
       const response = await transport.post('https://server.test/secure', 'hello');
+      assert(transport.getSessionRecoveryToken());
       const responseText = await response.text();
       assert.strictEqual(responseText, 'processed:hello');
+      assert.throws(
+        () => transport.getSessionRecoveryToken(),
+        /No session recovery token available/
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should retain the recovery token when the consumer cancels before EOF', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      const request = input instanceof Request ? input : new Request(input);
+      const encrypted = await buildEncryptedResponse(request, serverIdentity);
+      const body = new Uint8Array(await encrypted.arrayBuffer());
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(body.slice(0, body.length - 1));
+        },
+      }), {
+        status: encrypted.status,
+        headers: encrypted.headers,
+      });
+    }) as typeof fetch;
+
+    try {
+      const response = await transport.post('https://server.test/secure', 'hello');
+      const token = transport.getSessionRecoveryToken();
+
+      await response.body!.cancel('consumer stopped');
+
+      assert.deepStrictEqual(transport.getSessionRecoveryToken(), token);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should not let older stream completion clear the latest recovery token', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+
+    const originalFetch = globalThis.fetch;
+    let requestCount = 0;
+    let finishFirstResponse!: () => void;
+    let secondRequestEnc = '';
+    globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      const request = input instanceof Request ? input : new Request(input);
+      const encrypted = await buildEncryptedResponse(request, serverIdentity);
+      requestCount++;
+      if (requestCount === 2) {
+        secondRequestEnc = request.headers.get(PROTOCOL.ENCAPSULATED_KEY_HEADER) ?? '';
+        return encrypted;
+      }
+
+      const body = new Uint8Array(await encrypted.arrayBuffer());
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(body);
+          finishFirstResponse = () => controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: encrypted.status,
+        headers: encrypted.headers,
+      });
+    }) as typeof fetch;
+
+    try {
+      const first = await transport.post('https://server.test/secure', 'first');
+      const second = await transport.post('https://server.test/secure', 'second');
+      assert.strictEqual(
+        bytesToHex(transport.getSessionRecoveryToken().requestEnc),
+        secondRequestEnc
+      );
+
+      const firstText = first.text();
+      finishFirstResponse();
+      assert.strictEqual(await firstText, 'processed:first');
+      assert.strictEqual(
+        bytesToHex(transport.getSessionRecoveryToken().requestEnc),
+        secondRequestEnc
+      );
+
+      await second.body!.cancel('test complete');
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -330,14 +443,24 @@ describe('Transport', () => {
     try {
       const controller = new AbortController();
       const response = await transport.post('https://server.test/secure', 'hello', {
+        cache: 'no-store',
         credentials: 'include',
+        integrity: 'sha256-test',
+        mode: 'cors',
         redirect: 'manual',
+        referrer: 'https://client.test/page',
+        referrerPolicy: 'origin',
         signal: controller.signal,
       });
       assert.strictEqual(await response.text(), 'processed:hello');
 
+      assert.strictEqual(capturedRequest.cache, 'no-store');
       assert.strictEqual(capturedRequest.credentials, 'include');
+      assert.strictEqual(capturedRequest.integrity, 'sha256-test');
+      assert.strictEqual(capturedRequest.mode, 'cors');
       assert.strictEqual(capturedRequest.redirect, 'manual');
+      assert.strictEqual(capturedRequest.referrer, 'https://client.test/page');
+      assert.strictEqual(capturedRequest.referrerPolicy, 'origin');
 
       // The outgoing request's signal must follow the caller's signal
       assert.strictEqual(capturedRequest.signal.aborted, false);
@@ -391,16 +514,62 @@ describe('Transport', () => {
       const request = new Request('https://server.test/secure', {
         method: 'POST',
         body: 'hello',
+        cache: 'reload',
         credentials: 'include',
+        integrity: 'sha256-request',
+        mode: 'cors',
         redirect: 'manual',
+        referrer: 'https://client.test/request',
+        referrerPolicy: 'strict-origin',
         duplex: 'half',
       } as RequestInit);
+      const expectedRequest = new Request(request.clone(), { credentials: 'omit' });
       const response = await transport.request(request, { credentials: 'omit' });
       assert.strictEqual(await response.text(), 'processed:hello');
 
       // init overrides the Request; unset init members fall back to it
-      assert.strictEqual(capturedRequest.credentials, 'omit');
-      assert.strictEqual(capturedRequest.redirect, 'manual');
+      assert.strictEqual(capturedRequest.cache, expectedRequest.cache);
+      assert.strictEqual(capturedRequest.credentials, expectedRequest.credentials);
+      assert.strictEqual(capturedRequest.integrity, expectedRequest.integrity);
+      assert.strictEqual(capturedRequest.mode, expectedRequest.mode);
+      assert.strictEqual(capturedRequest.redirect, expectedRequest.redirect);
+      assert.strictEqual(capturedRequest.referrer, expectedRequest.referrer);
+      assert.strictEqual(capturedRequest.referrerPolicy, expectedRequest.referrerPolicy);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should let init override Request method, headers, and body, like fetch()', async () => {
+    const serverIdentity = await Identity.generate();
+    const transport = new Transport(serverIdentity, 'server.test');
+
+    const originalFetch = globalThis.fetch;
+    let capturedRequest!: Request;
+
+    globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      capturedRequest = input as Request;
+      return buildEncryptedResponse(capturedRequest.clone(), serverIdentity);
+    }) as typeof fetch;
+
+    try {
+      const request = new Request('https://server.test/secure', {
+        method: 'POST',
+        headers: { 'x-source': 'request', 'x-replaced': 'request' },
+        body: 'request body',
+        duplex: 'half',
+      } as RequestInit);
+      const response = await transport.request(request, {
+        method: 'PUT',
+        headers: { 'x-init': 'init', 'x-replaced': 'init' },
+        body: 'init body',
+      });
+
+      assert.strictEqual(await response.text(), 'processed:init body');
+      assert.strictEqual(capturedRequest.method, 'PUT');
+      assert.strictEqual(capturedRequest.headers.get('x-init'), 'init');
+      assert.strictEqual(capturedRequest.headers.get('x-replaced'), 'init');
+      assert.strictEqual(capturedRequest.headers.get('x-source'), null);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/js/src/test/session-recovery.test.ts
+++ b/js/src/test/session-recovery.test.ts
@@ -630,6 +630,35 @@ describe('Session Recovery Token', () => {
       );
     });
 
+    it('should cancel upstream and reject downstream when the error callback throws', async () => {
+      const token: SessionRecoveryToken = {
+        exportedSecret: new Uint8Array(32),
+        requestEnc: new Uint8Array(32),
+      };
+
+      let upstreamCancelled = false;
+      const upstream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x00]));
+        },
+        cancel() {
+          upstreamCancelled = true;
+        },
+      });
+      const nonce = bytesToHex(new Uint8Array(RESPONSE_NONCE_LENGTH));
+      const response = new Response(upstream, {
+        status: 200,
+        headers: { [PROTOCOL.RESPONSE_NONCE_HEADER]: nonce },
+      });
+
+      const decrypted = await decryptResponseWithToken(response, token, () => {
+        throw new Error('error callback failed');
+      });
+
+      await assert.rejects(() => decrypted.text(), /maximum allowed size/);
+      assert.strictEqual(upstreamCancelled, true);
+    });
+
     it('should fail decryption with a wrong token', async () => {
       const { identity, privateKey } = await generateTestKeys();
       const request = new Request('https://server.test/api', {

--- a/js/src/test/session-recovery.test.ts
+++ b/js/src/test/session-recovery.test.ts
@@ -797,7 +797,7 @@ describe('Session Recovery Token', () => {
       );
     });
 
-    it('should return a working token after a request', async () => {
+    it('should clear the token after the response is fully consumed', async () => {
       const { identity, privateKey } = await generateTestKeys();
       const { Transport } = await import('../client.js');
       const transport = new Transport(identity, 'server.test');
@@ -814,10 +814,10 @@ describe('Session Recovery Token', () => {
         const responseText = await response.text();
         assert.strictEqual(responseText, 'via-transport');
 
-        // The token should now be available
-        const token = transport.getSessionRecoveryToken();
-        assert.strictEqual(token.exportedSecret.length, 32);
-        assert.strictEqual(token.requestEnc.length, 32);
+        assert.throws(
+          () => transport.getSessionRecoveryToken(),
+          /No session recovery token available/
+        );
       } finally {
         globalThis.fetch = originalFetch;
       }
@@ -882,6 +882,221 @@ describe('Session Recovery Token', () => {
           /No session recovery token available/,
           'Token should be cleared after bodyless request'
         );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('should let only the latest request publish its token', async () => {
+      const { identity, privateKey } = await generateTestKeys();
+      const { Transport } = await import('../client.js');
+      const transport = new Transport(identity, 'server.test');
+
+      const originalFetch = globalThis.fetch;
+      let releaseFirst!: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let firstFetchStarted!: () => void;
+      const firstStarted = new Promise<void>((resolve) => {
+        firstFetchStarted = resolve;
+      });
+      let requestCount = 0;
+      let secondRequestEnc = '';
+
+      globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+        const request = input instanceof Request ? input : new Request(input);
+        requestCount++;
+        if (requestCount === 1) {
+          firstFetchStarted();
+          await firstGate;
+        } else {
+          secondRequestEnc = request.headers.get(PROTOCOL.ENCAPSULATED_KEY_HEADER)!;
+        }
+        return buildEncryptedResponse(request, privateKey, 'ok');
+      }) as typeof fetch;
+
+      try {
+        const first = transport.post('https://server.test/api', 'request-1');
+        await firstStarted;
+        const second = transport.post('https://server.test/api', 'request-2');
+
+        await second;
+        assert.strictEqual(
+          bytesToHex(transport.getSessionRecoveryToken().requestEnc),
+          secondRequestEnc,
+        );
+
+        releaseFirst();
+        await first;
+        assert.strictEqual(
+          bytesToHex(transport.getSessionRecoveryToken().requestEnc),
+          secondRequestEnc,
+          'an older response must not replace the latest token',
+        );
+      } finally {
+        releaseFirst();
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('should invalidate the previous token when a newer request starts', async () => {
+      const { identity, privateKey } = await generateTestKeys();
+      const { Transport } = await import('../client.js');
+      const transport = new Transport(identity, 'server.test');
+
+      const originalFetch = globalThis.fetch;
+      let releaseSecond!: () => void;
+      const secondGate = new Promise<void>((resolve) => {
+        releaseSecond = resolve;
+      });
+      let secondFetchStarted!: () => void;
+      const secondStarted = new Promise<void>((resolve) => {
+        secondFetchStarted = resolve;
+      });
+      let requestCount = 0;
+
+      globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+        const request = input instanceof Request ? input : new Request(input);
+        requestCount++;
+        if (requestCount === 2) {
+          secondFetchStarted();
+          await secondGate;
+        }
+        return buildEncryptedResponse(request, privateKey, 'ok');
+      }) as typeof fetch;
+
+      try {
+        await transport.post('https://server.test/api', 'request-1');
+        assert(transport.getSessionRecoveryToken());
+
+        const second = transport.post('https://server.test/api', 'request-2');
+        await secondStarted;
+        assert.throws(
+          () => transport.getSessionRecoveryToken(),
+          /No session recovery token available/,
+        );
+
+        releaseSecond();
+        await second;
+        assert(transport.getSessionRecoveryToken());
+      } finally {
+        releaseSecond();
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('should clear only its own token after a stream authentication failure', async () => {
+      const { identity, privateKey } = await generateTestKeys();
+      const { Transport } = await import('../client.js');
+      const transport = new Transport(identity, 'server.test');
+
+      const originalFetch = globalThis.fetch;
+      let requestCount = 0;
+      let latestRequestEnc = '';
+
+      globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+        const request = input instanceof Request ? input : new Request(input);
+        requestCount++;
+        const response = await buildEncryptedResponse(request, privateKey, 'ok');
+        if (requestCount === 2) {
+          latestRequestEnc = request.headers.get(PROTOCOL.ENCAPSULATED_KEY_HEADER)!;
+          return response;
+        }
+
+        const nonce = response.headers.get(PROTOCOL.RESPONSE_NONCE_HEADER)!;
+        const corrupted = new Uint8Array(await response.arrayBuffer());
+        corrupted[corrupted.length - 1] ^= 1;
+        return new Response(toArrayBuffer(corrupted), {
+          headers: { [PROTOCOL.RESPONSE_NONCE_HEADER]: nonce },
+        });
+      }) as typeof fetch;
+
+      try {
+        const olderResponse = await transport.post('https://server.test/api', 'request-1');
+        const latestResponse = await transport.post('https://server.test/api', 'request-2');
+        await assert.rejects(() => olderResponse.text(), /Decryption failed/);
+        assert.strictEqual(
+          bytesToHex(transport.getSessionRecoveryToken().requestEnc),
+          latestRequestEnc,
+          'an older stream failure must not clear the latest token',
+        );
+        assert.strictEqual(await latestResponse.text(), 'ok');
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('should clear the latest token after its stream authentication failure', async () => {
+      const { identity, privateKey } = await generateTestKeys();
+      const { Transport } = await import('../client.js');
+      const transport = new Transport(identity, 'server.test');
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+        const request = input instanceof Request ? input : new Request(input);
+        const response = await buildEncryptedResponse(request, privateKey, 'ok');
+        const nonce = response.headers.get(PROTOCOL.RESPONSE_NONCE_HEADER)!;
+        const corrupted = new Uint8Array(await response.arrayBuffer());
+        corrupted[corrupted.length - 1] ^= 1;
+        return new Response(toArrayBuffer(corrupted), {
+          headers: { [PROTOCOL.RESPONSE_NONCE_HEADER]: nonce },
+        });
+      }) as typeof fetch;
+
+      try {
+        const response = await transport.post('https://server.test/api', 'request');
+        assert(transport.getSessionRecoveryToken());
+        await assert.rejects(() => response.text(), /Decryption failed/);
+        assert.throws(
+          () => transport.getSessionRecoveryToken(),
+          /No session recovery token available/,
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('should clear the latest token and cancel upstream after a read failure', async () => {
+      const { identity } = await generateTestKeys();
+      const { Transport } = await import('../client.js');
+      const transport = new Transport(identity, 'server.test');
+
+      const originalFetch = globalThis.fetch;
+      const readError = new Error('upstream read failed');
+      let rejectRead!: (error: Error) => void;
+      const readResult = new Promise<ReadableStreamReadResult<Uint8Array>>((_, reject) => {
+        rejectRead = reject;
+      });
+      let cancelReason: unknown;
+      globalThis.fetch = (async (): Promise<Response> => {
+        const source = new ReadableStream<Uint8Array>();
+        Object.defineProperty(source, 'getReader', {
+          value: () => ({
+            read: () => readResult,
+            cancel: async (reason?: unknown) => {
+              cancelReason = reason;
+            },
+          }),
+        });
+        return new Response(source, {
+          headers: {
+            [PROTOCOL.RESPONSE_NONCE_HEADER]:
+              bytesToHex(new Uint8Array(RESPONSE_NONCE_LENGTH)),
+          },
+        });
+      }) as typeof fetch;
+
+      try {
+        const response = await transport.post('https://server.test/api', 'request');
+        assert(transport.getSessionRecoveryToken());
+        rejectRead(readError);
+        await assert.rejects(response.text(), (error) => error === readError);
+        assert.throws(
+          () => transport.getSessionRecoveryToken(),
+          /No session recovery token available/,
+        );
+        assert.strictEqual(cancelReason, readError);
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/python/src/ehbp/client.py
+++ b/python/src/ehbp/client.py
@@ -97,6 +97,7 @@ class Client:
         self._max_response_bytes = max_response_bytes
         self._token_lock = threading.Lock()
         self._last_token: Optional[SessionRecoveryToken] = None
+        self._request_generation = 0
 
     @classmethod
     def discover(
@@ -193,7 +194,7 @@ class Client:
     ) -> Response:
         url = self._resolve_url(path_or_url)
         request_headers, plaintext = self._prepare_body(headers, body, json_body)
-        self._set_token(None)
+        generation = self._begin_request()
         encrypted = self._identity.encrypt_request_body(plaintext)
 
         if encrypted is None:
@@ -205,7 +206,7 @@ class Client:
 
         request_headers[ENCAPSULATED_KEY_HEADER] = encrypted.encapsulated_key.hex()
         token = encrypted.token
-        self._set_token(token)
+        self._publish_token(generation, token)
         try:
             with self._http.stream(
                 method,
@@ -220,12 +221,13 @@ class Client:
             _raise_for_key_config_mismatch(status, response_headers, raw)
             response_nonce = _response_nonce_for_status(status, response_headers)
             if response_nonce is None:
-                self._clear_token_if_current(token)
+                self._clear_token_if_current(generation)
                 return Response(status, response_headers, raw)
             decrypted = token.decrypt_response_body(response_nonce, raw)
         except BaseException:
-            self._clear_token_if_current(token)
+            self._clear_token_if_current(generation)
             raise
+        self._clear_token_if_current(generation)
         return Response(status, response_headers, decrypted)
 
     def get(self, path_or_url: str, *, headers: HeadersInput = None) -> Response:
@@ -266,7 +268,7 @@ class Client:
     ) -> Iterator[StreamingResponse]:
         url = self._resolve_url(path_or_url)
         request_headers, plaintext = self._prepare_body(headers, body, json_body)
-        self._set_token(None)
+        generation = self._begin_request()
         encrypted = self._identity.encrypt_request_body(plaintext)
 
         if encrypted is None:
@@ -278,7 +280,7 @@ class Client:
 
         request_headers[ENCAPSULATED_KEY_HEADER] = encrypted.encapsulated_key.hex()
         token = encrypted.token
-        self._set_token(token)
+        self._publish_token(generation, token)
         try:
             with self._http.stream(
                 method,
@@ -291,7 +293,7 @@ class Client:
                 response_headers = resp.headers
                 if RESPONSE_NONCE_HEADER not in response_headers:
                     raw = self._read_body_capped(resp)
-                    self._clear_token_if_current(token)
+                    self._clear_token_if_current(generation)
                     _raise_for_key_config_mismatch(status, response_headers, raw)
                     response_nonce = _response_nonce_for_status(status, response_headers)
                     if response_nonce is None:
@@ -303,14 +305,20 @@ class Client:
                 yield StreamingResponse(
                     status,
                     response_headers,
-                    self._decrypt_stream(resp, token, response_nonce),
+                    self._decrypt_stream(resp, token, response_nonce, generation),
                 )
+        except GeneratorExit:
+            raise
         except BaseException:
-            self._clear_token_if_current(token)
+            self._clear_token_if_current(generation)
             raise
 
     def _decrypt_stream(
-        self, resp: httpx.Response, token: SessionRecoveryToken, response_nonce: bytes
+        self,
+        resp: httpx.Response,
+        token: SessionRecoveryToken,
+        response_nonce: bytes,
+        generation: int,
     ) -> Iterator[bytes]:
         decryptor = token.create_response_decryptor(
             response_nonce, max_chunk_length=self._max_response_bytes
@@ -319,8 +327,11 @@ class Client:
             for chunk in resp.iter_bytes():
                 yield from decryptor.push(chunk)
             decryptor.finish()
+            self._clear_token_if_current(generation)
+        except GeneratorExit:
+            raise
         except BaseException:
-            self._clear_token_if_current(token)
+            self._clear_token_if_current(generation)
             raise
 
     def _prepare_body(
@@ -364,13 +375,20 @@ class Client:
             raise InvalidInputError("request URL must not include credentials")
         return url
 
-    def _set_token(self, token: Optional[SessionRecoveryToken]) -> None:
+    def _begin_request(self) -> int:
         with self._token_lock:
-            self._last_token = token
+            self._request_generation += 1
+            self._last_token = None
+            return self._request_generation
 
-    def _clear_token_if_current(self, token: SessionRecoveryToken) -> None:
+    def _publish_token(self, generation: int, token: SessionRecoveryToken) -> None:
         with self._token_lock:
-            if self._last_token == token:
+            if self._request_generation == generation:
+                self._last_token = token
+
+    def _clear_token_if_current(self, generation: int) -> None:
+        with self._token_lock:
+            if self._request_generation == generation:
                 self._last_token = None
 
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -1,5 +1,7 @@
 """Client behavior tests against the in-process EHBP mock server."""
 
+import threading
+
 import httpx
 import pytest
 
@@ -11,7 +13,7 @@ from ehbp.errors import (
     KeyConfigMismatchError,
     ProtocolError,
 )
-from ehbp.protocol import ENCAPSULATED_KEY_HEADER, RESPONSE_NONCE_HEADER
+from ehbp.protocol import RESPONSE_NONCE_HEADER
 
 
 def test_encrypted_round_trip(server: MockServer):
@@ -46,14 +48,136 @@ def test_bodyless_request_passes_through_as_plaintext(server: MockServer):
     assert client.get_session_recovery_token() is None
 
 
-def test_successful_request_retains_session_recovery_token(server: MockServer):
+def test_successful_request_clears_session_recovery_token(server: MockServer):
     client = server.make_client()
     client.post("/v1/echo", body=b"payload")
-    token = client.get_session_recovery_token()
-    assert token is not None
-    assert token.request_enc == bytes.fromhex(
-        server.last_request.headers[ENCAPSULATED_KEY_HEADER]
+    assert client.get_session_recovery_token() is None
+
+
+def test_streaming_request_clears_session_recovery_token_after_full_consumption(make_server):
+    server = make_server(chunk_size=4)
+    client = server.make_client()
+
+    with client.stream("POST", "/v1/echo", body=b"payload") as response:
+        assert client.get_session_recovery_token() is not None
+        assert b"".join(response.iter_bytes()) == b"echo:payload"
+
+    assert client.get_session_recovery_token() is None
+
+
+def test_streaming_request_retains_session_recovery_token_after_partial_consumption(make_server):
+    server = make_server(chunk_size=4)
+    client = server.make_client()
+
+    with client.stream("POST", "/v1/echo", body=b"payload") as response:
+        next(iter(response))
+
+    assert client.get_session_recovery_token() is not None
+
+
+def test_older_stream_completion_does_not_clear_newer_recovery_token(make_server):
+    server = make_server(chunk_size=4)
+    client = server.make_client()
+
+    with client.stream("POST", "/v1/echo", body=b"older") as older:
+        with client.stream("POST", "/v1/echo", body=b"newer"):
+            newer_token = client.get_session_recovery_token()
+            assert newer_token is not None
+            assert b"".join(older.iter_bytes()) == b"echo:older"
+            assert client.get_session_recovery_token() == newer_token
+
+
+@pytest.mark.parametrize("older_api", ["request", "stream"])
+@pytest.mark.parametrize("older_outcome", ["success", "error"])
+def test_older_request_cannot_publish_or_clear_newer_recovery_token(
+    make_server, monkeypatch, older_api, older_outcome
+):
+    server = make_server(chunk_size=4)
+    older_encryption_started = threading.Event()
+    release_older_encryption = threading.Event()
+    older_request_started = threading.Event()
+    release_older_request = threading.Event()
+    newer_request_started = threading.Event()
+    release_newer_request = threading.Event()
+    original_encrypt = ServerIdentity.encrypt_request_body
+
+    def encrypt(identity, plaintext):
+        if plaintext == b"older":
+            older_encryption_started.set()
+            if not release_older_encryption.wait(5):
+                raise RuntimeError("timed out waiting to release older encryption")
+        return original_encrypt(identity, plaintext)
+
+    monkeypatch.setattr(ServerIdentity, "encrypt_request_body", encrypt)
+
+    def handler(request):
+        if request.url.path == "/older":
+            older_request_started.set()
+            if not release_older_request.wait(5):
+                raise RuntimeError("timed out waiting to release older request")
+            if older_outcome == "error":
+                raise RuntimeError("older request failed")
+        else:
+            newer_request_started.set()
+            if not release_newer_request.wait(5):
+                raise RuntimeError("timed out waiting to release newer request")
+        return server.handler(request)
+
+    client = Client(
+        DEFAULT_BASE_URL,
+        ServerIdentity.from_public_key_bytes(server.public_key_bytes),
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
     )
+    errors = []
+
+    def run_older():
+        try:
+            if older_api == "request":
+                client.post("/older", body=b"older")
+            else:
+                with client.stream("POST", "/older", body=b"older") as response:
+                    assert b"".join(response.iter_bytes()) == b"echo:older"
+        except BaseException as error:
+            errors.append(error)
+
+    def run_newer():
+        try:
+            client.post("/newer", body=b"newer")
+        except BaseException as error:
+            errors.append(error)
+
+    older_thread = threading.Thread(target=run_older, daemon=True)
+    newer_thread = threading.Thread(target=run_newer, daemon=True)
+    try:
+        older_thread.start()
+        assert older_encryption_started.wait(5)
+        newer_thread.start()
+        assert newer_request_started.wait(5)
+        newer_token = client.get_session_recovery_token()
+        assert newer_token is not None
+
+        release_older_encryption.set()
+        assert older_request_started.wait(5)
+        assert client.get_session_recovery_token() is newer_token
+
+        release_older_request.set()
+        older_thread.join(5)
+        assert not older_thread.is_alive()
+        assert client.get_session_recovery_token() is newer_token
+    finally:
+        release_older_encryption.set()
+        release_older_request.set()
+        release_newer_request.set()
+        older_thread.join(5)
+        newer_thread.join(5)
+
+    assert not newer_thread.is_alive()
+    if older_outcome == "error":
+        assert len(errors) == 1
+        assert str(errors[0]) == "older request failed"
+    else:
+        assert errors == []
+    assert client.get_session_recovery_token() is None
 
 
 def test_encrypted_body_uses_chunked_transfer_without_content_length(server: MockServer):
@@ -127,7 +251,7 @@ def test_encrypted_non_success_response_is_decrypted(make_server):
     response = client.post("/v1/echo", body=b"payload")
     assert response.status_code == 503
     assert response.content == b"echo:payload"
-    assert client.get_session_recovery_token() is not None
+    assert client.get_session_recovery_token() is None
 
 
 def test_key_config_mismatch_raises_dedicated_error(make_server):

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -29,13 +29,20 @@ use crate::{
 };
 
 const DEFAULT_MAX_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
+const MAX_PROBLEM_DETAILS_BYTES: usize = 64 * 1024;
 
 #[derive(Clone)]
 pub struct Client {
     base_url: Url,
     identity: ServerIdentity,
     http_client: reqwest::Client,
-    last_session_recovery_token: Arc<Mutex<Option<SessionRecoveryToken>>>,
+    session: Arc<Mutex<SessionState>>,
+}
+
+#[derive(Default)]
+struct SessionState {
+    generation: u64,
+    token: Option<SessionRecoveryToken>,
 }
 
 impl Client {
@@ -112,7 +119,7 @@ impl Client {
             base_url,
             identity,
             http_client,
-            last_session_recovery_token: Arc::new(Mutex::new(None)),
+            session: Arc::new(Mutex::new(SessionState::default())),
         })
     }
 
@@ -125,21 +132,30 @@ impl Client {
     }
 
     pub fn get_session_recovery_token(&self) -> Option<SessionRecoveryToken> {
-        self.last_session_recovery_token.lock().ok()?.clone()
+        self.session.lock().ok()?.token.clone()
     }
 
     pub fn take_session_recovery_token(&self) -> Option<SessionRecoveryToken> {
-        self.last_session_recovery_token.lock().ok()?.take()
+        self.session.lock().ok()?.token.take()
     }
 
-    fn replace_session_recovery_token(&self, token: Option<SessionRecoveryToken>) {
-        if let Ok(mut guard) = self.last_session_recovery_token.lock() {
-            *guard = token;
+    fn begin_request(&self) -> u64 {
+        let mut state = self.session.lock().expect("session mutex poisoned");
+        state.generation = state.generation.wrapping_add(1);
+        state.token = None;
+        state.generation
+    }
+
+    fn publish_session_recovery_token(&self, generation: u64, token: SessionRecoveryToken) {
+        if let Ok(mut state) = self.session.lock() {
+            if state.generation == generation {
+                state.token = Some(token);
+            }
         }
     }
 
-    fn clear_session_recovery_token_if_current(&self, token: &SessionRecoveryToken) {
-        clear_session_recovery_token_if_current(&self.last_session_recovery_token, token);
+    fn clear_session_recovery_token_if_current(&self, generation: u64) {
+        clear_session_recovery_token_if_current(&self.session, generation);
     }
 
     pub fn request(&self, method: Method, path_or_url: impl AsRef<str>) -> Result<RequestBuilder> {
@@ -170,15 +186,19 @@ impl Client {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn execute(&self, request: reqwest::Request) -> Result<reqwest::Response> {
-        let PreparedRawRequest { request, token } = self.prepare_raw_request(request).await?;
-        let mut guard = token.as_ref().map(|token| {
-            SessionGuard::new(token.clone(), Arc::clone(&self.last_session_recovery_token))
-        });
+        let PreparedRawRequest {
+            request,
+            token,
+            generation,
+        } = self.prepare_raw_request(request).await?;
+        let mut guard = token
+            .as_ref()
+            .map(|_| SessionGuard::new(generation, Arc::clone(&self.session)));
         let response = match self.http_client.execute(request).await {
             Ok(response) => response,
             Err(err) => return Err(err.into()),
         };
-        let response = self.open_raw_response(response, token).await?;
+        let response = self.open_raw_response(response, token, generation).await?;
         if let Some(guard) = guard.as_mut() {
             guard.disarm();
         }
@@ -190,13 +210,14 @@ impl Client {
         &self,
         mut request: reqwest::Request,
     ) -> Result<PreparedRawRequest> {
+        let generation = self.begin_request();
         self.validate_raw_request(&request)?;
-        self.replace_session_recovery_token(None);
 
         let Some(body) = request.body_mut().take() else {
             return Ok(PreparedRawRequest {
                 request,
                 token: None,
+                generation,
             });
         };
 
@@ -209,6 +230,7 @@ impl Client {
                     return Ok(PreparedRawRequest {
                         request,
                         token: None,
+                        generation,
                     });
                 }
             }
@@ -236,11 +258,12 @@ impl Client {
         request.headers_mut().remove(CONTENT_LENGTH);
         request.headers_mut().remove(TRANSFER_ENCODING);
         *request.body_mut() = Some(reqwest::Body::wrap_stream(encrypted));
-        self.replace_session_recovery_token(Some(token.clone()));
+        self.publish_session_recovery_token(generation, token.clone());
 
         Ok(PreparedRawRequest {
             request,
             token: Some(token),
+            generation,
         })
     }
 
@@ -249,6 +272,7 @@ impl Client {
         &self,
         mut response: reqwest::Response,
         token: Option<SessionRecoveryToken>,
+        generation: u64,
     ) -> Result<reqwest::Response> {
         let Some(token) = token else {
             return Ok(response);
@@ -257,7 +281,9 @@ impl Client {
         let version = response.version();
         let url = response.url().clone();
         let extensions = std::mem::take(response.extensions_mut());
-        let opened = self.open_encrypted_response(response, token).await?;
+        let opened = self
+            .open_encrypted_response(response, token, generation)
+            .await?;
         let mut builder = http::Response::builder()
             .status(opened.status)
             .version(version);
@@ -278,9 +304,9 @@ impl Client {
         &self,
         response: reqwest::Response,
         token: SessionRecoveryToken,
+        generation: u64,
     ) -> Result<OpenedEncryptedResponse> {
-        let mut guard =
-            SessionGuard::new(token.clone(), Arc::clone(&self.last_session_recovery_token));
+        let mut guard = SessionGuard::new(generation, Arc::clone(&self.session));
         let status = response.status();
         let mut headers = response.headers().clone();
 
@@ -292,11 +318,7 @@ impl Client {
             }
 
             let body = if is_problem_json_status(status, &headers) {
-                let body = read_response_body_capped(response, DEFAULT_MAX_RESPONSE_BYTES).await?;
-                check_key_config_mismatch(status, &headers, &body)?;
-                Box::pin(async_stream::stream! {
-                    yield Ok(body);
-                }) as Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>
+                inspect_problem_response(response, status, &headers).await?
             } else {
                 Box::pin(response.bytes_stream().map_reqwest_error())
             };
@@ -316,8 +338,8 @@ impl Client {
                 response.bytes_stream(),
                 key_material,
             )),
-            token,
-            session: Arc::clone(&self.last_session_recovery_token),
+            generation,
+            session: Arc::clone(&self.session),
             cleared: false,
         });
         guard.disarm();
@@ -349,11 +371,14 @@ impl Client {
         headers: HeaderMap,
         body: Option<Bytes>,
     ) -> Result<Response> {
-        let PreparedRequest { request, token } =
-            self.prepare_request_builder(method, url, headers, body)?;
-        let mut guard = token.as_ref().map(|token| {
-            SessionGuard::new(token.clone(), Arc::clone(&self.last_session_recovery_token))
-        });
+        let PreparedRequest {
+            request,
+            token,
+            generation,
+        } = self.prepare_request_builder(method, url, headers, body)?;
+        let mut guard = token
+            .as_ref()
+            .map(|_| SessionGuard::new(generation, Arc::clone(&self.session)));
         let response = request.send().await?;
         let status = response.status();
         let headers = response.headers().clone();
@@ -380,7 +405,7 @@ impl Client {
 
         let response_nonce = response_nonce(&headers)?;
         let decrypted = token.decrypt_response_body(&response_nonce, &body)?;
-        self.clear_session_recovery_token_if_current(&token);
+        self.clear_session_recovery_token_if_current(generation);
         if let Some(guard) = guard.as_mut() {
             guard.disarm();
         }
@@ -401,11 +426,14 @@ impl Client {
         headers: HeaderMap,
         body: Option<Bytes>,
     ) -> Result<StreamingResponse> {
-        let PreparedRequest { request, token } =
-            self.prepare_request_builder(method, url, headers, body)?;
-        let mut guard = token.as_ref().map(|token| {
-            SessionGuard::new(token.clone(), Arc::clone(&self.last_session_recovery_token))
-        });
+        let PreparedRequest {
+            request,
+            token,
+            generation,
+        } = self.prepare_request_builder(method, url, headers, body)?;
+        let mut guard = token
+            .as_ref()
+            .map(|_| SessionGuard::new(generation, Arc::clone(&self.session)));
         let response = request.send().await?;
 
         let Some(token) = token else {
@@ -416,7 +444,9 @@ impl Client {
             });
         };
 
-        let opened = self.open_encrypted_response(response, token).await?;
+        let opened = self
+            .open_encrypted_response(response, token, generation)
+            .await?;
         if let Some(guard) = guard.as_mut() {
             guard.disarm();
         }
@@ -435,7 +465,7 @@ impl Client {
         body: Option<Bytes>,
     ) -> Result<PreparedRequest> {
         let plaintext_body = body.unwrap_or_default();
-        self.replace_session_recovery_token(None);
+        let generation = self.begin_request();
         let encrypted = self.identity.encrypt_request_body(&plaintext_body)?;
 
         let mut request = self.http_client.request(method, url);
@@ -445,7 +475,7 @@ impl Client {
                 HeaderValue::from_str(&hex::encode(&encrypted.encapsulated_key))?,
             );
             let token = encrypted.token;
-            self.replace_session_recovery_token(Some(token.clone()));
+            self.publish_session_recovery_token(generation, token.clone());
             request = request
                 .headers(headers)
                 .body(encrypted_reqwest_body(encrypted.body));
@@ -455,7 +485,11 @@ impl Client {
             None
         };
 
-        Ok(PreparedRequest { request, token })
+        Ok(PreparedRequest {
+            request,
+            token,
+            generation,
+        })
     }
 
     fn resolve_url(&self, path_or_url: &str) -> Result<Url> {
@@ -491,12 +525,14 @@ pub struct RequestBuilder {
 struct PreparedRequest {
     request: reqwest::RequestBuilder,
     token: Option<SessionRecoveryToken>,
+    generation: u64,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 struct PreparedRawRequest {
     request: reqwest::Request,
     token: Option<SessionRecoveryToken>,
+    generation: u64,
 }
 
 struct OpenedEncryptedResponse {
@@ -673,13 +709,10 @@ fn encrypted_reqwest_body(body: Vec<u8>) -> reqwest::Body {
     })
 }
 
-fn clear_session_recovery_token_if_current(
-    session: &Arc<Mutex<Option<SessionRecoveryToken>>>,
-    token: &SessionRecoveryToken,
-) {
-    if let Ok(mut guard) = session.lock() {
-        if guard.as_ref() == Some(token) {
-            *guard = None;
+fn clear_session_recovery_token_if_current(session: &Arc<Mutex<SessionState>>, generation: u64) {
+    if let Ok(mut state) = session.lock() {
+        if state.generation == generation {
+            state.token = None;
         }
     }
 }
@@ -729,6 +762,9 @@ fn check_key_config_mismatch(status: StatusCode, headers: &HeaderMap, body: &[u8
     if media_type != PROBLEM_JSON_MEDIA_TYPE {
         return Ok(());
     }
+    if body.len() > MAX_PROBLEM_DETAILS_BYTES {
+        return Ok(());
+    }
 
     let Ok(problem) = serde_json::from_slice::<serde_json::Value>(body) else {
         return Ok(());
@@ -742,6 +778,59 @@ fn check_key_config_mismatch(status: StatusCode, headers: &HeaderMap, body: &[u8
     }
 
     Ok(())
+}
+
+async fn inspect_problem_response(
+    response: reqwest::Response,
+    status: StatusCode,
+    headers: &HeaderMap,
+) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>> {
+    let mut stream = Box::pin(response.bytes_stream());
+    let mut prefix = BytesMut::with_capacity(MAX_PROBLEM_DETAILS_BYTES + 1);
+
+    while prefix.len() <= MAX_PROBLEM_DETAILS_BYTES {
+        let Some(chunk) = std::future::poll_fn(|cx| stream.as_mut().poll_next(cx)).await else {
+            let body = prefix.freeze();
+            check_key_config_mismatch(status, headers, &body)?;
+            return Ok(Box::pin(async_stream::stream! {
+                yield Ok(body);
+            }));
+        };
+        let chunk = chunk?;
+        let remaining = MAX_PROBLEM_DETAILS_BYTES + 1 - prefix.len();
+        if chunk.len() <= remaining {
+            prefix.extend_from_slice(&chunk);
+        } else {
+            prefix.extend_from_slice(&chunk[..remaining]);
+            let tail = chunk.slice(remaining..);
+            let prefix = prefix.freeze();
+            return Ok(Box::pin(async_stream::try_stream! {
+                yield prefix;
+                if !tail.is_empty() {
+                    yield tail;
+                }
+                while let Some(chunk) =
+                    std::future::poll_fn(|cx| stream.as_mut().poll_next(cx)).await
+                {
+                    yield chunk?;
+                }
+            }));
+        }
+
+        if prefix.len() > MAX_PROBLEM_DETAILS_BYTES {
+            let prefix = prefix.freeze();
+            return Ok(Box::pin(async_stream::try_stream! {
+                yield prefix;
+                while let Some(chunk) =
+                    std::future::poll_fn(|cx| stream.as_mut().poll_next(cx)).await
+                {
+                    yield chunk?;
+                }
+            }));
+        }
+    }
+
+    unreachable!()
 }
 
 fn is_problem_json_status(status: StatusCode, headers: &HeaderMap) -> bool {
@@ -793,21 +882,21 @@ where
 
 struct SessionClearingStream {
     inner: Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>,
-    token: SessionRecoveryToken,
-    session: Arc<Mutex<Option<SessionRecoveryToken>>>,
+    generation: u64,
+    session: Arc<Mutex<SessionState>>,
     cleared: bool,
 }
 
 struct SessionGuard {
-    token: SessionRecoveryToken,
-    session: Arc<Mutex<Option<SessionRecoveryToken>>>,
+    generation: u64,
+    session: Arc<Mutex<SessionState>>,
     active: bool,
 }
 
 impl SessionGuard {
-    fn new(token: SessionRecoveryToken, session: Arc<Mutex<Option<SessionRecoveryToken>>>) -> Self {
+    fn new(generation: u64, session: Arc<Mutex<SessionState>>) -> Self {
         Self {
-            token,
+            generation,
             session,
             active: true,
         }
@@ -821,7 +910,7 @@ impl SessionGuard {
 impl Drop for SessionGuard {
     fn drop(&mut self) {
         if self.active {
-            clear_session_recovery_token_if_current(&self.session, &self.token);
+            clear_session_recovery_token_if_current(&self.session, self.generation);
         }
     }
 }
@@ -829,7 +918,7 @@ impl Drop for SessionGuard {
 impl SessionClearingStream {
     fn clear_if_current(&mut self) {
         if !self.cleared {
-            clear_session_recovery_token_if_current(&self.session, &self.token);
+            clear_session_recovery_token_if_current(&self.session, self.generation);
             self.cleared = true;
         }
     }
@@ -1061,6 +1150,35 @@ mod tests {
             err,
             Error::Protocol(message) if message.contains("exceeds maximum allowed size")
         ));
+    }
+
+    #[tokio::test]
+    async fn oversized_problem_diagnostics_remain_streaming_passthrough() {
+        let body = Bytes::from(format!(
+            r#"{{"type":"{KEY_CONFIG_PROBLEM_TYPE}","title":"{}"}}"#,
+            "x".repeat(MAX_PROBLEM_DETAILS_BYTES)
+        ));
+        let response = reqwest::Response::from(
+            http::Response::builder()
+                .status(StatusCode::UNPROCESSABLE_ENTITY)
+                .header(CONTENT_TYPE, PROBLEM_JSON_MEDIA_TYPE)
+                .body(reqwest::Body::from(body.clone()))
+                .unwrap(),
+        );
+        let status = response.status();
+        let headers = response.headers().clone();
+
+        let streamed = inspect_problem_response(response, status, &headers)
+            .await
+            .unwrap()
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()
+            .unwrap()
+            .concat();
+
+        assert_eq!(streamed, body);
     }
 
     #[tokio::test]
@@ -1406,6 +1524,7 @@ mod tests {
             .build()
             .unwrap();
         let prepared = client.prepare_raw_request(request).await.unwrap();
+        let generation = prepared.generation;
         let token = prepared.token.unwrap();
         let response_nonce = [9u8; RESPONSE_NONCE_LENGTH];
         let key_material =
@@ -1436,7 +1555,7 @@ mod tests {
         response.extensions_mut().insert(Marker(7));
 
         let response = client
-            .open_raw_response(response, Some(token))
+            .open_raw_response(response, Some(token), generation)
             .await
             .unwrap();
 
@@ -1469,7 +1588,7 @@ mod tests {
         let response = reqwest::Response::from(response);
 
         let err = client
-            .open_raw_response(response, prepared.token)
+            .open_raw_response(response, prepared.token, prepared.generation)
             .await
             .unwrap_err();
 
@@ -1496,7 +1615,11 @@ mod tests {
             .unwrap();
 
         let response = client
-            .open_raw_response(reqwest::Response::from(response), prepared.token)
+            .open_raw_response(
+                reqwest::Response::from(response),
+                prepared.token,
+                prepared.generation,
+            )
             .await
             .unwrap();
 
@@ -1522,6 +1645,7 @@ mod tests {
                 .unwrap()
         };
         let first = client.prepare_raw_request(build_request()).await.unwrap();
+        let first_generation = first.generation;
         let first_token = first.token.unwrap();
         let second = client.prepare_raw_request(build_request()).await.unwrap();
         let second_token = second.token.unwrap();
@@ -1533,7 +1657,7 @@ mod tests {
         );
 
         let response = client
-            .open_raw_response(response, Some(first_token))
+            .open_raw_response(response, Some(first_token), first_generation)
             .await
             .unwrap();
 
@@ -1795,15 +1919,65 @@ mod tests {
 
     #[test]
     fn token_cleanup_does_not_clear_newer_request_token() {
-        let first = SessionRecoveryToken::new(vec![1; 32], vec![2; 32]).unwrap();
         let second = SessionRecoveryToken::new(vec![3; 32], vec![4; 32]).unwrap();
-        let session = Arc::new(Mutex::new(Some(second.clone())));
+        let session = Arc::new(Mutex::new(SessionState {
+            generation: 2,
+            token: Some(second.clone()),
+        }));
 
-        clear_session_recovery_token_if_current(&session, &first);
-        assert_eq!(session.lock().unwrap().as_ref(), Some(&second));
+        clear_session_recovery_token_if_current(&session, 1);
+        assert_eq!(session.lock().unwrap().token.as_ref(), Some(&second));
 
-        clear_session_recovery_token_if_current(&session, &second);
-        assert!(session.lock().unwrap().is_none());
+        clear_session_recovery_token_if_current(&session, 2);
+        assert!(session.lock().unwrap().token.is_none());
+    }
+
+    #[tokio::test]
+    async fn stalled_older_raw_request_cannot_overwrite_or_clear_newer_token() {
+        let (client, _) = raw_client_with_private_key();
+        let first_polled = Arc::new(tokio::sync::Notify::new());
+        let release_first = Arc::new(tokio::sync::Notify::new());
+        let first_polled_by_stream = Arc::clone(&first_polled);
+        let release_first_stream = Arc::clone(&release_first);
+        let body = async_stream::stream! {
+            yield Ok::<Bytes, std::io::Error>(Bytes::new());
+            first_polled_by_stream.notify_one();
+            release_first_stream.notified().await;
+            yield Ok(Bytes::from_static(b"older"));
+        };
+        let first_request = reqwest::Client::new()
+            .post("https://example.com/v1/chat")
+            .body(reqwest::Body::wrap_stream(body))
+            .build()
+            .unwrap();
+        let first_client = client.clone();
+        let first_task =
+            tokio::spawn(async move { first_client.prepare_raw_request(first_request).await });
+
+        first_polled.notified().await;
+        let second_request = reqwest::Client::new()
+            .post("https://example.com/v1/chat")
+            .body("newer")
+            .build()
+            .unwrap();
+        let second = client.prepare_raw_request(second_request).await.unwrap();
+        let second_token = second.token.unwrap();
+
+        release_first.notify_one();
+        let first = first_task.await.unwrap().unwrap();
+        assert_eq!(
+            client.get_session_recovery_token().as_ref(),
+            Some(&second_token)
+        );
+
+        drop(SessionGuard::new(
+            first.generation,
+            Arc::clone(&client.session),
+        ));
+        assert_eq!(
+            client.get_session_recovery_token().as_ref(),
+            Some(&second_token)
+        );
     }
 
     #[tokio::test]

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -210,8 +210,8 @@ impl Client {
         &self,
         mut request: reqwest::Request,
     ) -> Result<PreparedRawRequest> {
-        let generation = self.begin_request();
         self.validate_raw_request(&request)?;
+        let generation = self.begin_request();
 
         let Some(body) = request.body_mut().take() else {
             return Ok(PreparedRawRequest {
@@ -1671,18 +1671,34 @@ mod tests {
     #[tokio::test]
     async fn raw_transport_rejects_unsafe_request_identity() {
         let (client, _) = raw_client_with_private_key();
+        let valid = reqwest::Client::new()
+            .post("https://example.com/v1/chat")
+            .body("secret")
+            .build()
+            .unwrap();
+        let prepared = client.prepare_raw_request(valid).await.unwrap();
+        let generation = prepared.generation;
+        let token = prepared.token.unwrap();
+        let assert_session_unchanged = || {
+            let state = client.session.lock().unwrap();
+            assert_eq!(state.generation, generation);
+            assert_eq!(state.token.as_ref(), Some(&token));
+        };
+
         let cross_origin = reqwest::Client::new()
             .post("https://evil.example/v1/chat")
             .body("secret")
             .build()
             .unwrap();
         assert!(client.prepare_raw_request(cross_origin).await.is_err());
+        assert_session_unchanged();
 
         let credential_url = reqwest::Request::new(
             Method::POST,
             Url::parse("https://user@example.com/v1/chat").unwrap(),
         );
         assert!(client.prepare_raw_request(credential_url).await.is_err());
+        assert_session_unchanged();
 
         let reserved_header = reqwest::Client::new()
             .post("https://example.com/v1/chat")
@@ -1691,6 +1707,7 @@ mod tests {
             .build()
             .unwrap();
         assert!(client.prepare_raw_request(reserved_header).await.is_err());
+        assert_session_unchanged();
     }
 
     #[tokio::test]

--- a/swift/Sources/EHBP/Client.swift
+++ b/swift/Sources/EHBP/Client.swift
@@ -7,6 +7,9 @@ public final class EHBPClient: @unchecked Sendable {
     private let session: URLSession
     private let tokenLock = NSLock()
     private var _lastSessionRecoveryToken: SessionRecoveryToken?
+    private var requestGeneration: UInt64 = 0
+
+    private static let passThroughChunkSize = 16 * 1024
 
     /// Creates a new EHBP client
     ///
@@ -64,6 +67,7 @@ public final class EHBPClient: @unchecked Sendable {
         guard let url = URL(string: urlString) else {
             throw EHBPError.invalidInput("invalid URL: \(urlString)")
         }
+        let generation = beginRequest()
 
         var request = URLRequest(url: url)
         request.httpMethod = method
@@ -85,10 +89,6 @@ public final class EHBPClient: @unchecked Sendable {
                 forHTTPHeaderField: EHBPProtocol.encapsulatedKeyHeader
             )
             request.httpBody = encryptedBody
-        } else {
-            tokenLock.lock()
-            _lastSessionRecoveryToken = nil
-            tokenLock.unlock()
         }
 
         let (data, response) = try await session.data(for: request)
@@ -118,9 +118,7 @@ public final class EHBPClient: @unchecked Sendable {
             encryptedData: data
         )
 
-        tokenLock.lock()
-        _lastSessionRecoveryToken = token
-        tokenLock.unlock()
+        clearToken(for: generation)
 
         return (decryptedData, EHBPClient.sanitizedResponse(httpResponse))
     }
@@ -144,6 +142,7 @@ public final class EHBPClient: @unchecked Sendable {
         guard let url = URL(string: urlString) else {
             throw EHBPError.invalidInput("invalid URL: \(urlString)")
         }
+        let generation = beginRequest()
 
         var request = URLRequest(url: url)
         request.httpMethod = method
@@ -165,10 +164,6 @@ public final class EHBPClient: @unchecked Sendable {
                 forHTTPHeaderField: EHBPProtocol.encapsulatedKeyHeader
             )
             request.httpBody = encryptedBody
-        } else {
-            tokenLock.lock()
-            _lastSessionRecoveryToken = nil
-            tokenLock.unlock()
         }
 
         let (asyncBytes, response) = try await session.bytes(for: request)
@@ -181,23 +176,19 @@ public final class EHBPClient: @unchecked Sendable {
             from: httpResponse,
             requestWasEncrypted: requestContext != nil
         ) else {
-            let stream = AsyncThrowingStream<Data, Error> { continuation in
-                let task = Task {
-                    do {
-                        var buffer = Data()
-                        for try await byte in asyncBytes {
-                            buffer.append(byte)
-                        }
-                        if !buffer.isEmpty {
-                            continuation.yield(buffer)
-                        }
-                        continuation.finish()
-                    } catch {
-                        continuation.finish(throwing: error)
-                    }
-                }
-                continuation.onTermination = { _ in task.cancel() }
+            let chunker = PullDrivenByteChunker(
+                iterator: asyncBytes.makeAsyncIterator(),
+                chunkSize: EHBPClient.passThroughChunkSize,
+                onFailure: { self.clearToken(for: generation) },
+                onCancel: { asyncBytes.task.cancel() }
+            )
+            let lifetime = StreamCancellation {
+                asyncBytes.task.cancel()
             }
+            let stream = AsyncThrowingStream<Data, Error>(unfolding: {
+                _ = lifetime
+                return try await chunker.next()
+            })
             return (stream, httpResponse)
         }
 
@@ -209,31 +200,49 @@ public final class EHBPClient: @unchecked Sendable {
             responseNonce: responseNonce
         )
 
-        tokenLock.lock()
-        _lastSessionRecoveryToken = token
-        tokenLock.unlock()
+        publishToken(token!, for: generation)
 
-        let stream = AsyncThrowingStream<Data, Error> { continuation in
-            let task = Task {
-                do {
-                    var decryptor = responseDecryptor
-
-                    for try await byte in asyncBytes {
-                        if let plaintext = try decryptor.push(byte) {
-                            continuation.yield(plaintext)
-                        }
-                    }
-
-                    try decryptor.finish()
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
-            }
-            continuation.onTermination = { _ in task.cancel() }
+        let decryptor = PullDrivenResponseDecryptor(
+            iterator: asyncBytes.makeAsyncIterator(),
+            decryptor: responseDecryptor,
+            onComplete: { self.clearToken(for: generation) },
+            onFailure: { self.clearToken(for: generation) },
+            onCancel: { asyncBytes.task.cancel() }
+        )
+        let lifetime = StreamCancellation {
+            asyncBytes.task.cancel()
         }
+        let stream = AsyncThrowingStream<Data, Error>(unfolding: {
+            _ = lifetime
+            return try await decryptor.next()
+        })
 
         return (stream, EHBPClient.sanitizedResponse(httpResponse))
+    }
+
+    private func beginRequest() -> UInt64 {
+        tokenLock.lock()
+        requestGeneration &+= 1
+        let generation = requestGeneration
+        _lastSessionRecoveryToken = nil
+        tokenLock.unlock()
+        return generation
+    }
+
+    private func publishToken(_ token: SessionRecoveryToken, for generation: UInt64) {
+        tokenLock.lock()
+        if requestGeneration == generation {
+            _lastSessionRecoveryToken = token
+        }
+        tokenLock.unlock()
+    }
+
+    private func clearToken(for generation: UInt64) {
+        tokenLock.lock()
+        if requestGeneration == generation {
+            _lastSessionRecoveryToken = nil
+        }
+        tokenLock.unlock()
     }
 
     private static func responseNonceHex(
@@ -275,6 +284,132 @@ public final class EHBPClient: @unchecked Sendable {
         return sanitized
     }
 
+}
+
+actor PullDrivenByteChunker<Iterator: AsyncIteratorProtocol & Sendable>
+where Iterator.Element == UInt8 {
+    private var iterator: Iterator
+    private let chunkSize: Int
+    private let onFailure: @Sendable () -> Void
+    private let onCancel: @Sendable () -> Void
+    private var isReading = false
+
+    init(
+        iterator: Iterator,
+        chunkSize: Int,
+        onFailure: @escaping @Sendable () -> Void = {},
+        onCancel: @escaping @Sendable () -> Void = {}
+    ) {
+        precondition(chunkSize > 0)
+        self.iterator = iterator
+        self.chunkSize = chunkSize
+        self.onFailure = onFailure
+        self.onCancel = onCancel
+    }
+
+    func next() async throws -> Data? {
+        guard !isReading else {
+            throw EHBPError.invalidInput("concurrent stream iteration is unsupported")
+        }
+        isReading = true
+        defer { isReading = false }
+
+        do {
+            let cancel = onCancel
+            return try await withTaskCancellationHandler {
+                var iterator = self.iterator
+                var chunk = Data(capacity: chunkSize)
+                while chunk.count < chunkSize {
+                    guard let byte = try await iterator.next() else {
+                        self.iterator = iterator
+                        return chunk.isEmpty ? nil : chunk
+                    }
+                    chunk.append(byte)
+                }
+                self.iterator = iterator
+                return chunk
+            } onCancel: {
+                cancel()
+            }
+        } catch {
+            onFailure()
+            throw error
+        }
+    }
+}
+
+actor PullDrivenResponseDecryptor<Iterator: AsyncIteratorProtocol & Sendable>
+where Iterator.Element == UInt8 {
+    private var iterator: Iterator
+    private var decryptor: ResponseDecryptor
+    private let onComplete: @Sendable () -> Void
+    private let onFailure: @Sendable () -> Void
+    private let onCancel: @Sendable () -> Void
+    private var isReading = false
+    private var isFinished = false
+
+    init(
+        iterator: Iterator,
+        decryptor: ResponseDecryptor,
+        onComplete: @escaping @Sendable () -> Void = {},
+        onFailure: @escaping @Sendable () -> Void = {},
+        onCancel: @escaping @Sendable () -> Void = {}
+    ) {
+        self.iterator = iterator
+        self.decryptor = decryptor
+        self.onComplete = onComplete
+        self.onFailure = onFailure
+        self.onCancel = onCancel
+    }
+
+    func next() async throws -> Data? {
+        guard !isFinished else { return nil }
+        guard !isReading else {
+            throw EHBPError.invalidInput("concurrent stream iteration is unsupported")
+        }
+        isReading = true
+        defer { isReading = false }
+
+        do {
+            let cancel = onCancel
+            return try await withTaskCancellationHandler {
+                var iterator = self.iterator
+                var decryptor = self.decryptor
+                while let byte = try await iterator.next() {
+                    if let plaintext = try decryptor.push(byte) {
+                        self.iterator = iterator
+                        self.decryptor = decryptor
+                        return plaintext
+                    }
+                }
+                try decryptor.finish()
+                self.iterator = iterator
+                self.decryptor = decryptor
+                self.isFinished = true
+                self.onComplete()
+                return nil
+            } onCancel: {
+                cancel()
+            }
+        } catch {
+            if !Task.isCancelled {
+                onFailure()
+            }
+            throw error
+        }
+    }
+}
+
+private final class StreamCancellation: @unchecked Sendable {
+    private let cancel: @Sendable () -> Void
+
+    init(_ cancel: @escaping @Sendable () -> Void) {
+        self.cancel = cancel
+    }
+
+    deinit {
+        cancel()
+    }
 }
 
 // MARK: - Data Extensions

--- a/swift/Tests/EHBPTests/SessionRecoveryTests.swift
+++ b/swift/Tests/EHBPTests/SessionRecoveryTests.swift
@@ -434,6 +434,216 @@ final class SessionRecoveryTests: XCTestCase {
                      "stale Transfer-Encoding must not survive decryption")
         XCTAssertEqual(response.value(forHTTPHeaderField: "Content-Type"), "text/plain")
         XCTAssertNotNil(response.value(forHTTPHeaderField: EHBPProtocol.responseNonceHeader))
+        XCTAssertThrowsError(try client.getSessionRecoveryToken())
+    }
+
+    func testOlderBufferedCompletionPreservesLatestRecoveryToken() async throws {
+        let (_, serverPrivateKey) = makeIdentityAndServer()
+        let firstStarted = expectation(description: "first request started")
+
+        ControlledURLProtocol.handler = { [simulateServerResponse] request, index in
+            guard let encHex = request.value(forHTTPHeaderField: EHBPProtocol.encapsulatedKeyHeader),
+                  let requestEnc = Data(hexString: encHex) else {
+                throw EHBPError.invalidInput("missing encapsulated key header")
+            }
+            if index == 1 {
+                ControlledURLProtocol.setSecondRequestEnc(requestEnc)
+            }
+            let (responseNonce, encryptedBody) = try simulateServerResponse(
+                serverPrivateKey, requestEnc, Data("ok".utf8), nil
+            )
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: [EHBPProtocol.responseNonceHeader: responseNonce.hexString]
+            )!
+            return (response, encryptedBody)
+        }
+        ControlledURLProtocol.onFirstStarted = { firstStarted.fulfill() }
+        defer { ControlledURLProtocol.reset() }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ControlledURLProtocol.self]
+        let client = try EHBPClient(
+            baseURL: "https://server.test",
+            publicKey: Data(serverPrivateKey.publicKey.rawRepresentation),
+            session: URLSession(configuration: configuration)
+        )
+
+        let first = Task {
+            try await client.request(method: "POST", path: "/first", body: Data("first".utf8))
+        }
+        await fulfillment(of: [firstStarted], timeout: 2)
+
+        let (newerStream, _) = try await client.requestStream(
+            method: "POST",
+            path: "/second",
+            body: Data("second".utf8)
+        )
+        let expectedRequestEnc = ControlledURLProtocol.getSecondRequestEnc()
+        XCTAssertEqual(try client.getSessionRecoveryToken().requestEnc, expectedRequestEnc)
+
+        ControlledURLProtocol.releaseFirst()
+        _ = try await first.value
+        XCTAssertEqual(try client.getSessionRecoveryToken().requestEnc, expectedRequestEnc)
+        withExtendedLifetime(newerStream) {}
+    }
+
+    func testSuccessfulStreamingCompletionClearsRecoveryToken() async throws {
+        let (_, serverPrivateKey) = makeIdentityAndServer()
+
+        StubURLProtocol.handler = { [simulateServerResponse] request in
+            guard let encHex = request.value(forHTTPHeaderField: EHBPProtocol.encapsulatedKeyHeader),
+                  let requestEnc = Data(hexString: encHex) else {
+                throw EHBPError.invalidInput("missing encapsulated key header")
+            }
+            let (responseNonce, encryptedBody) = try simulateServerResponse(
+                serverPrivateKey, requestEnc, Data("ok".utf8), nil
+            )
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: [EHBPProtocol.responseNonceHeader: responseNonce.hexString]
+            )!
+            return (response, encryptedBody)
+        }
+        defer { StubURLProtocol.handler = nil }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let client = try EHBPClient(
+            baseURL: "https://server.test",
+            publicKey: Data(serverPrivateKey.publicKey.rawRepresentation),
+            session: URLSession(configuration: configuration)
+        )
+
+        let (stream, _) = try await client.requestStream(
+            method: "POST",
+            path: "/secure",
+            body: Data("hello".utf8)
+        )
+        XCTAssertNoThrow(try client.getSessionRecoveryToken())
+
+        var iterator = stream.makeAsyncIterator()
+        let plaintext = try await iterator.next()
+        XCTAssertEqual(plaintext, Data("ok".utf8))
+        XCTAssertNoThrow(try client.getSessionRecoveryToken())
+        let end = try await iterator.next()
+        XCTAssertNil(end)
+        XCTAssertThrowsError(try client.getSessionRecoveryToken())
+        let repeatedEnd = try await iterator.next()
+        XCTAssertNil(repeatedEnd)
+    }
+
+    func testLatestStreamingFailureClearsRecoveryToken() async throws {
+        let (_, serverPrivateKey) = makeIdentityAndServer()
+
+        StubURLProtocol.handler = { [simulateServerResponse] request in
+            guard let encHex = request.value(forHTTPHeaderField: EHBPProtocol.encapsulatedKeyHeader),
+                  let requestEnc = Data(hexString: encHex) else {
+                throw EHBPError.invalidInput("missing encapsulated key header")
+            }
+            let (responseNonce, encryptedBody) = try simulateServerResponse(
+                serverPrivateKey, requestEnc, Data("ok".utf8), nil
+            )
+            var corrupted = encryptedBody
+            corrupted[corrupted.index(before: corrupted.endIndex)] ^= 1
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: [EHBPProtocol.responseNonceHeader: responseNonce.hexString]
+            )!
+            return (response, corrupted)
+        }
+        defer { StubURLProtocol.handler = nil }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let client = try EHBPClient(
+            baseURL: "https://server.test",
+            publicKey: Data(serverPrivateKey.publicKey.rawRepresentation),
+            session: URLSession(configuration: configuration)
+        )
+
+        let (stream, _) = try await client.requestStream(
+            method: "POST",
+            path: "/secure",
+            body: Data("hello".utf8)
+        )
+        XCTAssertNoThrow(try client.getSessionRecoveryToken())
+
+        do {
+            for try await _ in stream {}
+            XCTFail("expected stream authentication failure")
+        } catch {
+            XCTAssertThrowsError(try client.getSessionRecoveryToken())
+        }
+    }
+
+    func testOlderStreamingFailurePreservesNewerRecoveryToken() async throws {
+        let (_, serverPrivateKey) = makeIdentityAndServer()
+
+        DelayedFailureURLProtocol.handler = { [simulateServerResponse] request, index in
+            guard let encHex = request.value(forHTTPHeaderField: EHBPProtocol.encapsulatedKeyHeader),
+                  let requestEnc = Data(hexString: encHex) else {
+                throw EHBPError.invalidInput("missing encapsulated key header")
+            }
+            if index == 1 {
+                DelayedFailureURLProtocol.setSecondRequestEnc(requestEnc)
+            }
+            let plaintext = index == 0
+                ? Data(repeating: 0x41, count: 16 * 1024 + 2)
+                : Data("ok".utf8)
+            let chunkSizes = index == 0 ? [16 * 1024, 2] : nil
+            let (responseNonce, encryptedBody) = try simulateServerResponse(
+                serverPrivateKey, requestEnc, plaintext, chunkSizes
+            )
+            var body = encryptedBody
+            if index == 0 {
+                body[body.index(before: body.endIndex)] ^= 1
+            }
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: [EHBPProtocol.responseNonceHeader: responseNonce.hexString]
+            )!
+            return (response, body)
+        }
+        defer { DelayedFailureURLProtocol.reset() }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DelayedFailureURLProtocol.self]
+        let client = try EHBPClient(
+            baseURL: "https://server.test",
+            publicKey: Data(serverPrivateKey.publicKey.rawRepresentation),
+            session: URLSession(configuration: configuration)
+        )
+
+        let (olderStream, _) = try await client.requestStream(
+            method: "POST",
+            path: "/older",
+            body: Data("older".utf8)
+        )
+        let (newerStream, _) = try await client.requestStream(
+            method: "POST",
+            path: "/newer",
+            body: Data("newer".utf8)
+        )
+        let expectedRequestEnc = DelayedFailureURLProtocol.getSecondRequestEnc()
+        XCTAssertEqual(try client.getSessionRecoveryToken().requestEnc, expectedRequestEnc)
+
+        DelayedFailureURLProtocol.releaseFirstBody()
+        do {
+            for try await _ in olderStream {}
+            XCTFail("expected older stream authentication failure")
+        } catch {
+            XCTAssertEqual(try client.getSessionRecoveryToken().requestEnc, expectedRequestEnc)
+        }
+        withExtendedLifetime(newerStream) {}
     }
 }
 
@@ -460,4 +670,157 @@ final class StubURLProtocol: URLProtocol {
     }
 
     override func stopLoading() {}
+}
+
+private final class ControlledURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest, Int) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var onFirstStarted: (() -> Void)?
+    nonisolated(unsafe) static var firstDelivery: (() -> Void)?
+    nonisolated(unsafe) static var requestCount = 0
+    nonisolated(unsafe) static var secondRequestEnc = Data()
+    private static let lock = NSLock()
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock()
+        let index = Self.requestCount
+        Self.requestCount += 1
+        Self.lock.unlock()
+
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: EHBPError.invalidInput("no controlled handler"))
+            return
+        }
+        do {
+            let (response, data) = try handler(request, index)
+            let deliver = { [weak self] in
+                guard let self else { return }
+                self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                self.client?.urlProtocol(self, didLoad: data)
+                self.client?.urlProtocolDidFinishLoading(self)
+            }
+            if index == 0 {
+                Self.lock.lock()
+                Self.firstDelivery = deliver
+                Self.lock.unlock()
+                Self.onFirstStarted?()
+            } else {
+                deliver()
+            }
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    static func releaseFirst() {
+        lock.lock()
+        let delivery = firstDelivery
+        firstDelivery = nil
+        lock.unlock()
+        delivery?()
+    }
+
+    static func setSecondRequestEnc(_ requestEnc: Data) {
+        lock.lock()
+        secondRequestEnc = requestEnc
+        lock.unlock()
+    }
+
+    static func getSecondRequestEnc() -> Data {
+        lock.lock()
+        let requestEnc = secondRequestEnc
+        lock.unlock()
+        return requestEnc
+    }
+
+    static func reset() {
+        releaseFirst()
+        lock.lock()
+        handler = nil
+        onFirstStarted = nil
+        requestCount = 0
+        secondRequestEnc = Data()
+        lock.unlock()
+    }
+}
+
+private final class DelayedFailureURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest, Int) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var firstBodyDelivery: (() -> Void)?
+    nonisolated(unsafe) static var requestCount = 0
+    nonisolated(unsafe) static var secondRequestEnc = Data()
+    private static let lock = NSLock()
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock()
+        let index = Self.requestCount
+        Self.requestCount += 1
+        Self.lock.unlock()
+
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: EHBPError.invalidInput("no delayed handler"))
+            return
+        }
+        do {
+            let (response, data) = try handler(request, index)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if index == 0 {
+                let finalByte = data.suffix(1)
+                client?.urlProtocol(self, didLoad: data.dropLast())
+                Self.lock.lock()
+                Self.firstBodyDelivery = { [weak self] in
+                    guard let self else { return }
+                    self.client?.urlProtocol(self, didLoad: finalByte)
+                    self.client?.urlProtocolDidFinishLoading(self)
+                }
+                Self.lock.unlock()
+            } else {
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            }
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    static func setSecondRequestEnc(_ requestEnc: Data) {
+        lock.lock()
+        secondRequestEnc = requestEnc
+        lock.unlock()
+    }
+
+    static func getSecondRequestEnc() -> Data {
+        lock.lock()
+        let requestEnc = secondRequestEnc
+        lock.unlock()
+        return requestEnc
+    }
+
+    static func releaseFirstBody() {
+        lock.lock()
+        let delivery = firstBodyDelivery
+        firstBodyDelivery = nil
+        lock.unlock()
+        delivery?()
+    }
+
+    static func reset() {
+        releaseFirstBody()
+        lock.lock()
+        handler = nil
+        requestCount = 0
+        secondRequestEnc = Data()
+        lock.unlock()
+    }
 }

--- a/swift/Tests/EHBPTests/StreamingTests.swift
+++ b/swift/Tests/EHBPTests/StreamingTests.swift
@@ -508,6 +508,47 @@ final class StreamingTests: XCTestCase {
         try decryptor.finish()
     }
 
+    func testPullDrivenResponseDecryptorReadsOneFramePerConsumerRequest() async throws {
+        let keyMaterial = try deriveResponseKeys(
+            exportedSecret: Data(repeating: 0xAB, count: EHBPConstants.exportLength),
+            requestEnc: Data(repeating: 0xCD, count: EHBPConstants.requestEncLength),
+            responseNonce: Data(repeating: 0xEF, count: EHBPConstants.responseNonceLength)
+        )
+        let first = try framedChunk(
+            keyMaterial: keyMaterial,
+            sequence: 0,
+            plaintext: Data("first".utf8)
+        )
+        let second = try framedChunk(
+            keyMaterial: keyMaterial,
+            sequence: 1,
+            plaintext: Data("second".utf8)
+        )
+        let source = CountingByteSource(bytes: Array(first + second))
+        let decryptor = PullDrivenResponseDecryptor(
+            iterator: source.makeIterator(),
+            decryptor: ResponseDecryptor(keyMaterial: keyMaterial)
+        )
+        let stream = AsyncThrowingStream<Data, Error>(unfolding: {
+            try await decryptor.next()
+        })
+
+        XCTAssertEqual(source.bytesRead, 0)
+        var iterator = stream.makeAsyncIterator()
+        let firstPlaintext = try await iterator.next()
+        XCTAssertEqual(firstPlaintext, Data("first".utf8))
+        XCTAssertEqual(source.bytesRead, first.count)
+
+        let secondPlaintext = try await iterator.next()
+        XCTAssertEqual(secondPlaintext, Data("second".utf8))
+        XCTAssertEqual(source.bytesRead, first.count + second.count)
+
+        let end = try await iterator.next()
+        XCTAssertNil(end)
+        let repeatedEnd = try await iterator.next()
+        XCTAssertNil(repeatedEnd)
+    }
+
     func testResponseDecryptorEnforcesSizeAndSequenceLimits() throws {
         let keyMaterial = try deriveResponseKeys(
             exportedSecret: Data(repeating: 0xAB, count: EHBPConstants.exportLength),

--- a/swift/Tests/EHBPTests/UnencryptedResponseTests.swift
+++ b/swift/Tests/EHBPTests/UnencryptedResponseTests.swift
@@ -20,6 +20,9 @@ final class UnencryptedResponseTests: XCTestCase {
     }
 
     override func tearDown() {
+        UnencryptedResponseURLProtocol.finishLoading?()
+        UnencryptedResponseURLProtocol.finishLoading = nil
+        UnencryptedResponseURLProtocol.streamWithoutFinishing = false
         UnencryptedResponseURLProtocol.statusCode = 500
         super.tearDown()
     }
@@ -72,10 +75,67 @@ final class UnencryptedResponseTests: XCTestCase {
             XCTAssertEqual(header, EHBPProtocol.responseNonceHeader)
         }
     }
+
+    func testStreamingPassThroughYieldsBeforeEndOfResponse() async throws {
+        UnencryptedResponseURLProtocol.streamWithoutFinishing = true
+        let client = try makeClient(statusCode: 429)
+        let (stream, _) = try await client.requestStream(
+            method: "POST",
+            path: "/secure",
+            body: Data("hello".utf8)
+        )
+
+        let yielded = expectation(description: "pass-through chunk yielded before EOF")
+        let task = Task {
+            do {
+                var iterator = stream.makeAsyncIterator()
+                let chunk = try await iterator.next()
+                XCTAssertEqual(chunk?.count, UnencryptedResponseURLProtocol.streamingChunkSize)
+                yielded.fulfill()
+            } catch {
+                XCTFail("unexpected stream error: \(error)")
+            }
+        }
+
+        await fulfillment(of: [yielded], timeout: 2)
+        UnencryptedResponseURLProtocol.finishLoading?()
+        UnencryptedResponseURLProtocol.finishLoading = nil
+        _ = await task.result
+    }
+
+    func testPassThroughChunkerReadsOnlyWhenConsumerRequestsNextChunk() async throws {
+        let source = CountingByteSource(bytes: Array(0..<10))
+        let chunker = PullDrivenByteChunker(
+            iterator: source.makeIterator(),
+            chunkSize: CountingByteSource.testChunkSize
+        )
+        let stream = AsyncThrowingStream<Data, Error>(unfolding: {
+            try await chunker.next()
+        })
+
+        XCTAssertEqual(source.bytesRead, 0)
+        var iterator = stream.makeAsyncIterator()
+        let first = try await iterator.next()
+        XCTAssertEqual(first, Data([0, 1, 2, 3]))
+        XCTAssertEqual(source.bytesRead, CountingByteSource.testChunkSize)
+
+        let second = try await iterator.next()
+        XCTAssertEqual(second, Data([4, 5, 6, 7]))
+        XCTAssertEqual(source.bytesRead, CountingByteSource.testChunkSize * 2)
+
+        let final = try await iterator.next()
+        XCTAssertEqual(final, Data([8, 9]))
+        XCTAssertEqual(source.bytesRead, 10)
+        let end = try await iterator.next()
+        XCTAssertNil(end)
+    }
 }
 
 private final class UnencryptedResponseURLProtocol: URLProtocol {
     nonisolated(unsafe) static var statusCode = 500
+    nonisolated(unsafe) static var streamWithoutFinishing = false
+    nonisolated(unsafe) static var finishLoading: (() -> Void)?
+    static let streamingChunkSize = 16 * 1024
 
     override class func canInit(with request: URLRequest) -> Bool { true }
 
@@ -89,9 +149,56 @@ private final class UnencryptedResponseURLProtocol: URLProtocol {
             headerFields: ["Content-Type": "text/plain"]
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if Self.streamWithoutFinishing {
+            client?.urlProtocol(self, didLoad: Data(repeating: 0x41, count: Self.streamingChunkSize))
+            Self.finishLoading = { [weak self] in
+                guard let self else { return }
+                self.client?.urlProtocolDidFinishLoading(self)
+            }
+            return
+        }
         client?.urlProtocol(self, didLoad: Data("upstream unavailable".utf8))
         client?.urlProtocolDidFinishLoading(self)
     }
 
     override func stopLoading() {}
+}
+
+final class CountingByteSource: @unchecked Sendable {
+    static let testChunkSize = 4
+
+    private let lock = NSLock()
+    private let bytes: [UInt8]
+    private var index = 0
+
+    init(bytes: [UInt8]) {
+        self.bytes = bytes
+    }
+
+    var bytesRead: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return index
+    }
+
+    func makeIterator() -> Iterator {
+        Iterator(source: self)
+    }
+
+    struct Iterator: AsyncIteratorProtocol, Sendable {
+        let source: CountingByteSource
+
+        mutating func next() async -> UInt8? {
+            source.next()
+        }
+    }
+
+    private func next() -> UInt8? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard index < bytes.count else { return nil }
+        let byte = bytes[index]
+        index += 1
+        return byte
+    }
 }


### PR DESCRIPTION
## Summary
- preserve native JavaScript request override semantics
- make recovery-token ownership generation-safe across all clients and clear consumed tokens
- harden Go authentication state/readers and bound internal problem diagnostics
- make Swift pass-through and decrypted streams pull-driven

## Validation
- Go race tests
- JavaScript build and tests
- Rust fmt, clippy, and tests
- Swift tests
- Python Ruff, mypy, and pytest

Release/version metadata is intentionally deferred.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves session-recovery token integrity across concurrent requests and at response boundaries (including bodyless responses), and hardens streaming and error handling across Go, JS, Python, Rust, and Swift. Caps problem-details parsing to 64 KiB, validates missing/empty response nonces, and keeps pass-through bodies intact.

- **Bug Fixes**
  - Token lifecycle: per-request generation; publish only the latest; clear on stream completion/error and on bodyless responses (JS/Python/Rust/Swift).
  - Streaming: make decrypted and pass-through responses pull-driven; read one encrypted frame per pull; ensure pass-through yields before end-of-response (Swift/JS).
  - Crypto/diagnostics: advance AEAD sequence only after successful auth and return the same terminal error on repeated reads; reject truncated frames; validate missing/empty response nonces; bound problem-details parsing to 64 KiB without consuming the original body (Go/JS/Rust).

<sup>Written for commit d5e57d0aeb9af1abee58eb03e62b1a39daeb552a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

