### PR TITLE
chore: bump version to v0.3.1

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ehbp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ehbp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@panva/hpke-noble": "^1.0.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ehbp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "JavaScript client for Encrypted HTTP Body Protocol (EHBP)",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tinfoil-ehbp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python client for the encrypted HTTP body protocol"
 license = "MIT"
 requires-python = ">=3.9"

--- a/python/src/ehbp/__init__.py
+++ b/python/src/ehbp/__init__.py
@@ -24,7 +24,7 @@ from .identity import EncryptedRequest, ServerIdentity
 from .session import SessionRecoveryToken
 from .transport import AsyncEHBPTransport, EHBPTransport
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     "Client",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "tinfoil-ehbp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm",
  "async-stream",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinfoil-ehbp"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.87"
 description = "Rust client for the encrypted HTTP body protocol"


### PR DESCRIPTION
## Summary
- bump JavaScript, Python, and Rust package metadata to 0.3.1
- keep JavaScript and Rust lockfiles synchronized
- prepare the shared `v0.3.1` tag used by Go and Swift

## Validation
- Go race tests
- JavaScript build and tests
- Python Ruff, mypy, and pytest
- Rust fmt, Clippy, and tests
- Swift tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump versions to 0.3.1 for `ehbp` (JavaScript) and `tinfoil-ehbp` (Python, Rust), and sync `package-lock.json` and `Cargo.lock`. Prepare the shared `v0.3.1` release tag for Go and Swift.

<sup>Written for commit 162a38686f3ac4629369130697aaf426be7cce5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/encrypted-http-body-protocol/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

