### PR TITLE
Preserve request payloads across browser and Go clients

### DIFF
--- a/identity/crypt.go
+++ b/identity/crypt.go
@@ -393,7 +393,7 @@ type RequestContext struct {
 // See SPEC.md Section 6.4 for the security rationale.
 func (i *Identity) EncryptRequestWithContext(req *http.Request) (*RequestContext, error) {
 	// Bodyless requests pass through unencrypted - no HPKE context needed
-	if req.Body == nil || req.Body == http.NoBody || req.ContentLength == 0 {
+	if req.Body == nil || req.Body == http.NoBody {
 		return nil, nil
 	}
 

--- a/identity/crypt.go
+++ b/identity/crypt.go
@@ -388,8 +388,8 @@ type RequestContext struct {
 // EncryptRequestWithContext encrypts the request body TO this identity's public key
 // and returns the HPKE context needed for response decryption.
 //
-// For bodyless requests (no body or empty body), returns nil - the request passes
-// through unencrypted and the response will also be unencrypted.
+// For requests whose body is nil or http.NoBody, returns nil - the request
+// passes through unencrypted and the response will also be unencrypted.
 // See SPEC.md Section 6.4 for the security rationale.
 func (i *Identity) EncryptRequestWithContext(req *http.Request) (*RequestContext, error) {
 	// Bodyless requests pass through unencrypted - no HPKE context needed

--- a/identity/crypt_test.go
+++ b/identity/crypt_test.go
@@ -103,9 +103,11 @@ func TestStreamingReaderEdgeCases(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("empty request body", func(t *testing.T) {
-		req := httptest.NewRequest("POST", "/test", strings.NewReader(""))
-		_, err := serverIdentity.EncryptRequestWithContext(req)
+		req, err := http.NewRequest("POST", "/test", strings.NewReader(""))
 		require.NoError(t, err)
+		ctx, err := serverIdentity.EncryptRequestWithContext(req)
+		require.NoError(t, err)
+		assert.Nil(t, ctx)
 		assert.Equal(t, int64(0), req.ContentLength)
 	})
 
@@ -113,6 +115,27 @@ func TestStreamingReaderEdgeCases(t *testing.T) {
 		req := httptest.NewRequest("POST", "/test", nil)
 		_, err := serverIdentity.EncryptRequestWithContext(req)
 		require.NoError(t, err)
+	})
+
+	t.Run("unknown request body length", func(t *testing.T) {
+		const testData = "non-empty body"
+		req, err := http.NewRequest(
+			"POST",
+			"/test",
+			io.NopCloser(strings.NewReader(testData)),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), req.ContentLength)
+
+		ctx, err := serverIdentity.EncryptRequestWithContext(req)
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+
+		_, err = serverIdentity.DecryptRequestWithContext(req)
+		require.NoError(t, err)
+		decryptedBody, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		assert.Equal(t, testData, string(decryptedBody))
 	})
 }
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ehbp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ehbp",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@panva/hpke-noble": "^1.0.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ehbp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "JavaScript client for Encrypted HTTP Body Protocol (EHBP)",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -160,9 +160,9 @@ export class Transport {
     // Normalize through the platform Request constructor first so RequestInit
     // overrides a Request input with the same semantics as fetch().
     const normalizedRequest = new Request(input, init);
-    const requestBody = normalizedRequest.body
-      ? await normalizedRequest.arrayBuffer()
-      : null;
+    // Firefox does not expose Request.body even when payload bytes are present.
+    const requestBodyBytes = await normalizedRequest.arrayBuffer();
+    const requestBody = requestBodyBytes.byteLength > 0 ? requestBodyBytes : null;
 
     const url = new URL(normalizedRequest.url);
     url.host = this.serverHost;

--- a/js/src/test/client.test.ts
+++ b/js/src/test/client.test.ts
@@ -631,6 +631,30 @@ describe('Transport', () => {
     }
   });
 
+  it('should preserve request payload when Request.body is unavailable', async () => {
+    const transport = new Transport(serverIdentity, 'server.test');
+    const originalFetch = globalThis.fetch;
+    const originalBody = Object.getOwnPropertyDescriptor(Request.prototype, 'body');
+    assert(originalBody);
+
+    globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      const request = input as Request;
+      return buildEncryptedResponse(request.clone(), serverIdentity);
+    }) as typeof fetch;
+    Object.defineProperty(Request.prototype, 'body', {
+      configurable: true,
+      get: () => null,
+    });
+
+    try {
+      const response = await transport.post('https://server.test/secure', 'firefox body');
+      assert.strictEqual(await response.text(), 'processed:firefox body');
+    } finally {
+      Object.defineProperty(Request.prototype, 'body', originalBody);
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('should preserve fetch options on bodyless passthrough requests', async () => {
     const serverIdentity = await Identity.generate();
     const transport = new Transport(serverIdentity, 'server.test');

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tinfoil-ehbp"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python client for the encrypted HTTP body protocol"
 license = "MIT"
 requires-python = ">=3.9"

--- a/python/src/ehbp/__init__.py
+++ b/python/src/ehbp/__init__.py
@@ -24,7 +24,7 @@ from .identity import EncryptedRequest, ServerIdentity
 from .session import SessionRecoveryToken
 from .transport import AsyncEHBPTransport, EHBPTransport
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = [
     "Client",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "tinfoil-ehbp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes-gcm",
  "async-stream",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinfoil-ehbp"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.87"
 description = "Rust client for the encrypted HTTP body protocol"


### PR DESCRIPTION
## Summary
- read JavaScript request bytes without relying on `Request.body`, which Firefox does not expose
- encrypt Go request bodies whose `ContentLength` is unknown instead of treating them as empty
- add regressions for Firefox-style requests and unknown-length Go streams
- bump all published EHBP clients to v0.3.2

## Testing
- `npm test` in `js/`
- `go test ./...`